### PR TITLE
fix: replace custom HTML escape table with stdlib html.escape()

### DIFF
--- a/docker_scanner.py
+++ b/docker_scanner.py
@@ -4,6 +4,7 @@ import subprocess
 import csv
 import pandas as pd
 import logging
+import html
 from typing import List, Tuple, Dict, Optional
 from datetime import datetime
 from fpdf import FPDF
@@ -1240,15 +1241,10 @@ class DockerSecurityScanner:
         if not text:
             return ""
         
-        html_escape_table = {
-            "&": "&amp;",
-            '"': "&quot;",
-            "'": "&#x27;",
-            ">": "&gt;",
-            "<": "&lt;",
-        }
+        if not isinstance(text, str):
+            text = str(text)
         
-        return "".join(html_escape_table.get(c, c) for c in str(text))
+        return html.escape(text, quote=True)
 
 def main():
     """Main function to run the security scanner."""

--- a/report_generator.py
+++ b/report_generator.py
@@ -16,6 +16,7 @@ import json
 import csv
 import re
 import logging
+import html
 from typing import Dict, List, Optional
 from datetime import datetime
 from fpdf import FPDF
@@ -467,15 +468,10 @@ class ReportGenerator:
         if not text:
             return ""
         
-        html_escape_table = {
-            "&": "&amp;",
-            '"': "&quot;",
-            "'": "&#x27;",
-            ">": "&gt;",
-            "<": "&lt;",
-        }
+        if not isinstance(text, str):
+            text = str(text)
         
-        return "".join(html_escape_table.get(c, c) for c in str(text))
+        return html.escape(text, quote=True)
     
     def _count_by_severity(self, vulnerabilities: List[Dict]) -> Dict[str, int]:
         """


### PR DESCRIPTION
## Description

Replaces custom `_escape_html()` implementation with Python standard library `html.escape(text, quote=True)` in both `docker_scanner.py` and `report_generator.py`. This provides more robust and maintained escaping for HTML reports.

## Changes

- Replaced manual dictionary-based escaping with `html.escape`.
- Simplified `_escape_html` method in both files.
- Added `import html` to both files.

Fixes #48