### PR TITLE
fix(security): Replace custom HTML escape with stdlib html.escape()

### DIFF
--- a/docker_scanner.py
+++ b/docker_scanner.py
@@ -4,6 +4,7 @@ import subprocess
 import csv
 import pandas as pd
 import logging
+import html
 from typing import List, Tuple, Dict, Optional
 from datetime import datetime
 from fpdf import FPDF
@@ -1230,25 +1231,17 @@ class DockerSecurityScanner:
     def _escape_html(self, text: str) -> str:
         """
         Escape HTML special characters in text.
-        
+
         Args:
             text: Text to escape
-            
+
         Returns:
             HTML-escaped text
         """
         if not text:
             return ""
-        
-        html_escape_table = {
-            "&": "&amp;",
-            '"': "&quot;",
-            "'": "&#x27;",
-            ">": "&gt;",
-            "<": "&lt;",
-        }
-        
-        return "".join(html_escape_table.get(c, c) for c in str(text))
+
+        return html.escape(str(text), quote=True)
 
 def main():
     """Main function to run the security scanner."""

--- a/report_generator.py
+++ b/report_generator.py
@@ -16,6 +16,7 @@ import json
 import csv
 import re
 import logging
+import html
 from typing import Dict, List, Optional
 from datetime import datetime
 from fpdf import FPDF
@@ -457,25 +458,17 @@ class ReportGenerator:
     def _escape_html(self, text: str) -> str:
         """
         Escape HTML special characters in text.
-        
+
         Args:
             text: Text to escape
-            
+
         Returns:
             HTML-escaped text
         """
         if not text:
             return ""
-        
-        html_escape_table = {
-            "&": "&amp;",
-            '"': "&quot;",
-            "'": "&#x27;",
-            ">": "&gt;",
-            "<": "&lt;",
-        }
-        
-        return "".join(html_escape_table.get(c, c) for c in str(text))
+
+        return html.escape(str(text), quote=True)
     
     def _count_by_severity(self, vulnerabilities: List[Dict]) -> Dict[str, int]:
         """


### PR DESCRIPTION
## Summary
Replaces custom HTML escape table with Python stdlib html.escape() for improved security.

## Changes
- Use html.escape(text, quote=True) instead of manual mapping
- Applied to both report_generator.py and docker_scanner.py
- Reduces ~24 lines to ~4 lines

## Security
Stdlib html.escape() is battle-tested and more secure.

Fixes #48