### PR TITLE
Fix for Unused import

### DIFF
--- a/docksec/score_calculator.py
+++ b/docksec/score_calculator.py
@@ -5,7 +5,6 @@ This module handles the calculation of security scores based on scan results.
 It uses LLM-based analysis to provide comprehensive security scoring.
 """
 
-import logging
 import re
 from typing import Dict
 from docksec.config import docker_score_prompt


### PR DESCRIPTION
The best fix is to delete the unused `import logging` line from `docksec/score_calculator.py` and leave all functional logic unchanged. This resolves the CodeQL warning without affecting behavior, since logging is already handled through `get_custom_logger`.

Specifically:
- File: `docksec/score_calculator.py`
- Region: top import block (around lines 8–12)
- Change: remove `import logging`
- No new methods/imports/definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._