### PR TITLE
feat: expose docker compose support in github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   image:
     description: 'Docker image name to scan'
     required: false
+  compose:
+    description: 'Path to docker-compose file to scan'
+    required: false
   output:
     description: 'Custom output file path'
     required: false
@@ -51,6 +54,7 @@ runs:
   env:
     INPUT_DOCKERFILE: ${{ inputs.dockerfile }}
     INPUT_IMAGE: ${{ inputs.image }}
+    INPUT_COMPOSE: ${{ inputs.compose }}
     INPUT_OUTPUT: ${{ inputs.output }}
     INPUT_OPENAI_API_KEY: ${{ inputs.openai_api_key }}
     INPUT_ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,6 +22,10 @@ if [ -n "${INPUT_IMAGE}" ]; then
   ARGS+=("-i" "${INPUT_IMAGE}")
 fi
 
+if [ -n "${INPUT_COMPOSE}" ]; then
+  ARGS+=("-c" "${INPUT_COMPOSE}")
+fi
+
 if [ -n "${INPUT_OUTPUT}" ]; then
   ARGS+=("-o" "${INPUT_OUTPUT}")
 fi


### PR DESCRIPTION
## Summary
Exposes the newly added Docker Compose scanning capabilities to the GitHub Action interface, allowing users to scan `docker-compose.yml` files directly in their CI/CD pipelines.

## Changes
- Updated `action.yml` to include a new `compose` input parameter.
- Updated `entrypoint.sh` to map the `INPUT_COMPOSE` environment variable to the `-c` CLI flag.