### PR TITLE
feat: add Grype scanner integration with dual-scanner deduplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ## What is DockSec?
 
-DockSec is an **OWASP Incubator Project** that bridges the gap between complex security scan results and actionable developer fixes. It integrates industry-standard scanners (Trivy, Hadolint, Docker Scout) with advanced AI to provide **context-aware security analysis**. 
+DockSec is an **OWASP Incubator Project** that bridges the gap between complex security scan results and actionable developer fixes. It integrates industry-standard scanners (Trivy, Grype, Hadolint, Docker Scout) with advanced AI to provide **context-aware security analysis**.
 
 Instead of overwhelming you with a list of 200+ CVEs, DockSec:
 
@@ -36,6 +36,7 @@ Instead of overwhelming you with a list of 200+ CVEs, DockSec:
 - **Explains** vulnerabilities in plain English, not just security jargon.
 - **Suggests** specific, line-by-line fixes for your Dockerfile.
 - **Generates** professional, interactive security reports for your team.
+- **Cross-validates** findings across multiple scanners so you catch what one scanner misses.
 
 Think of it as having a security expert sitting right next to you, reviewing your Dockerfiles in real-time.
 
@@ -49,10 +50,10 @@ Think of it as having a security expert sitting right next to you, reviewing you
 </div>
 
 DockSec follows a robust four-stage pipeline:
-1. **Scan**: Runs Trivy, Hadolint, and Docker Scout locally on your environment.
-2. **Analyze**: AI correlates findings across all scanners to remove noise and assess real-world impact.
+1. **Scan**: Runs Trivy and/or Grype for CVE detection, Hadolint for Dockerfile linting, and Docker Scout for base-image analysis — all locally on your environment.
+2. **Analyze**: AI correlates findings across all scanners to remove noise and assess real-world impact. When running both Trivy and Grype, results are automatically deduplicated and cross-validated.
 3. **Recommend**: Generates human-readable explanations and specific remediation steps.
-4. **Report**: Exports actionable results in JSON, PDF, HTML, or Markdown formats.
+4. **Report**: Exports actionable results in JSON, PDF, HTML, or CSV formats — each report includes a **Scanner Coverage** section showing exactly which scanner(s) flagged each CVE.
 
 ---
 
@@ -87,6 +88,9 @@ Integrate DockSec into your GitHub Actions workflow:
 # Install DockSec
 pip install docksec
 
+# Install all required external tools (Trivy, Hadolint, Grype)
+docksec-setup
+
 # Scan a Dockerfile (AI-powered)
 # Reports will be saved to ~/.docksec/results/
 docksec Dockerfile
@@ -104,18 +108,52 @@ docksec --image-only -i myapp:latest
 docksec Dockerfile --scan-only
 ```
 
+### Choosing a Vulnerability Scanner
+
+DockSec supports three scanner modes via the `--scanner` flag:
+
+```bash
+# Default: use Trivy only (fast, widely adopted)
+docksec --image-only -i myapp:latest --scanner trivy
+
+# Use Grype only (Anchore's scanner, often finds additional CVEs)
+docksec --image-only -i myapp:latest --scanner grype
+
+# Use both scanners and deduplicate results (maximum coverage)
+docksec --image-only -i myapp:latest --scanner all
+
+# Works with full scans too
+docksec Dockerfile -i myapp:latest --scanner all
+
+# Works with Docker Compose
+docksec --compose docker-compose.yml --scanner all
+```
+
+You can also set the default scanner via an environment variable (useful in CI/CD):
+
+```bash
+# Set a persistent default — no need to pass --scanner on every command
+export DOCKSEC_SCANNER=all
+docksec --image-only -i myapp:latest
+```
+
+> **Why use `--scanner all`?**
+> Trivy and Grype use different vulnerability databases and detection methods. In practice they each find CVEs the other misses. Running both and deduplicating gives you the highest confidence results — CVEs flagged by both scanners are shown with a **"Both"** badge in reports, making them the highest-priority findings to fix.
+
 ---
 
 ## Features
 
 - **Smart Analysis**: AI explains what vulnerabilities mean for *your* specific setup.
+- **Dual Vulnerability Scanner**: Choose Trivy, Grype, or run **both at once** (`--scanner all`) for maximum CVE coverage with automatic deduplication.
+- **Scanner Coverage Reports**: Every report includes a breakdown of which scanner(s) found each CVE — CVEs confirmed by both scanners are highlighted as highest priority.
 - **Multi-LLM Support**: Use OpenAI, Anthropic Claude (4.x), Google Gemini (1.5+), or local models via Ollama.
 - **Docker Compose Scanning**: Detect orchestration-level misconfigurations and scan all services in a compose file.
-- **Deep Integration**: Combines Trivy (vulnerabilities), Hadolint (linting), and Docker Scout.
+- **Deep Integration**: Combines Trivy, Grype, Hadolint (linting), and Docker Scout.
 - **Security Scoring**: Get a 0-100 score to track your security posture over time.
 - **Centralized Reporting**: All reports are neatly organized in `~/.docksec/results/` by default.
-- **Rich Formats**: Professional exports in HTML (interactive), PDF, JSON, and CSV.
-- **CI/CD Ready**: Designed for easy integration into GitHub Actions and build pipelines.
+- **Rich Formats**: Professional exports in HTML (interactive, with scanner badges), PDF, JSON, and CSV.
+- **CI/CD Ready**: Designed for easy integration into GitHub Actions and build pipelines. Set `DOCKSEC_SCANNER=all` in your environment for maximum coverage with no code changes.
 - **GitHub Action**: Available on the GitHub Marketplace for automated security scans.
 
 ---
@@ -129,15 +167,16 @@ Here is a comparison of how DockSec relates to other container security tools.
 | License and cost | Free, open source (MIT) | Free, open source (Apache 2.0) | Commercial (limited free tier) | Commercial (limited free tier) |
 | Governance | OWASP Incubator Project, vendor neutral | Open source, maintained by Aqua | Single vendor | Single vendor |
 | Detects CVEs and Dockerfile misconfigurations | Yes | Yes | Yes | Yes |
+| Dual scanner (Trivy + Grype) with deduplication | Yes (`--scanner all`) | No | No | No |
 | Contextual, line level Dockerfile remediation | Yes (line specific rewrites with explanation) | No (detection only) | Yes (base image upgrade advice, fix PRs) | Yes (AI AutoFix PRs) |
 | Runs fully offline / air gapped | Yes (local LLM via Ollama, scan only mode, no API key) | Yes for scanning (no remediation layer) | No (cloud platform) | No (hosted platform) |
 | Your image data stays on your network | Yes | Yes | No | No |
 | Bring your own LLM / model choice | Yes (OpenAI, Anthropic, Gemini, or local Ollama) | Not applicable | No (proprietary AI) | No (proprietary AI) |
 | Self hostable, no platform deployment | Yes | Yes | No | No |
 | Vendor lock in | None | None | Yes | Yes |
-| Security score (0 to 100) and multi format reports (HTML, PDF, JSON, CSV, Markdown) | Yes | Partial (machine formats, no remediation report) | Partial (dashboard reports) | Partial (dashboard reports) |
+| Security score (0 to 100) and multi format reports (HTML, PDF, JSON, CSV) | Yes | Partial (machine formats, no remediation report) | Partial (dashboard reports) | Partial (dashboard reports) |
 
-DockSec is the only one of these that pairs contextual, line level Dockerfile remediation with a fully open source, OWASP governed, locally runnable design. Snyk and Aikido offer capable AI remediation, but only as commercial cloud platforms that send your data to their service. Trivy is open source and local but stops at detection and does not help you fix anything. DockSec fills the gap for developers and for regulated or air gapped teams who need both the fix guidance and full control of their data, at no cost.
+DockSec is the only one of these that pairs contextual, line level Dockerfile remediation with a fully open source, OWASP governed, locally runnable design. Snyk and Aikido offer capable AI remediation, but only as commercial cloud platforms that send your data to their service. Trivy is open source and local but stops at detection and does not help you fix anything. DockSec fills the gap for developers and for regulated or air gapped teams who need both the fix guidance and full control of their data, at no cost. With `--scanner all`, DockSec runs both Trivy and Grype and automatically deduplicates the results — giving you broader CVE coverage than either scanner alone, without duplicates or extra noise.
 
 ---
 

--- a/docksec/cli.py
+++ b/docksec/cli.py
@@ -53,10 +53,18 @@ def main() -> None:
     parser.add_argument('--model', help='Model name to use (e.g., gpt-4o, claude-haiku-4-5, gemini-1.5-pro, llama3.1)')
     parser.add_argument('--compact-output', action='store_true', help='Use compact output format (less verbose)')
     parser.add_argument('--skip-ai-scoring', action='store_true', help='Skip AI-based security scoring (use local scoring only)')
+    parser.add_argument('--scanner', choices=['trivy', 'grype', 'all'], default=None,
+                        help='Vulnerability scanner to use: trivy (default), grype, or all (both, deduplicated). '
+                             'Can also be set via DOCKSEC_SCANNER environment variable.')
     parser.add_argument('--version', action='version', version=f'DockSec {get_version()}')
     
     args = parser.parse_args()
-    
+
+    # Resolve --scanner: CLI flag > DOCKSEC_SCANNER env var > default "trivy"
+    if args.scanner is None:
+        env_scanner = os.environ.get("DOCKSEC_SCANNER", "trivy").lower()
+        args.scanner = env_scanner if env_scanner in ("trivy", "grype", "all") else "trivy"
+
     # Set provider and model from CLI args if provided (overrides env vars)
     if args.provider:
         os.environ["LLM_PROVIDER"] = args.provider
@@ -151,6 +159,9 @@ def main() -> None:
     from docksec.config_manager import get_config
     from docksec.enums import LLMProvider
     print(f"[INFO] Reports will be saved to: {RESULTS_DIR}")
+    if run_scan:
+        scanner_label = {"trivy": "Trivy", "grype": "Grype", "all": "Trivy + Grype"}.get(args.scanner, args.scanner)
+        print(f"[INFO] Vulnerability scanner: {scanner_label}")
     if run_ai:
         config = get_config()
         print(f"[INFO] AI Provider: {config.llm_provider}")
@@ -223,7 +234,8 @@ def main() -> None:
                 orchestrator = ComposeOrchestrator(
                     args.compose,
                     scan_only=not run_ai,
-                    skip_ai_scoring=args.skip_ai_scoring
+                    skip_ai_scoring=args.skip_ai_scoring,
+                    scanner=args.scanner,
                 )
                 print(f"Scanning Compose file: {args.compose}")
                 results = orchestrator.run_full_scan("CRITICAL,HIGH")
@@ -236,10 +248,11 @@ def main() -> None:
                 # Initialize the scanner
                 dockerfile_path = None if args.image_only else args.dockerfile
                 scanner = DockerSecurityScanner(
-                    dockerfile_path, 
-                    args.image, 
+                    dockerfile_path,
+                    args.image,
                     scan_only=not run_ai,
-                    skip_ai_scoring=args.skip_ai_scoring
+                    skip_ai_scoring=args.skip_ai_scoring,
+                    scanner=args.scanner,
                 )
                 
                 # Run appropriate scan based on mode

--- a/docksec/compose_scanner.py
+++ b/docksec/compose_scanner.py
@@ -327,10 +327,11 @@ class ComposeScanner:
         return self.data.get('services', {})
 
 class ComposeOrchestrator:
-    def __init__(self, compose_path: str, scan_only: bool = False, skip_ai_scoring: bool = False):
+    def __init__(self, compose_path: str, scan_only: bool = False, skip_ai_scoring: bool = False, scanner: str = "trivy"):
         self.compose_path = compose_path
         self.scan_only = scan_only
         self.skip_ai_scoring = skip_ai_scoring
+        self.vuln_scanner = scanner
         self.scanner = ComposeScanner(compose_path)
         
     def run_full_scan(self, severity: str = "CRITICAL,HIGH") -> Dict:
@@ -389,7 +390,8 @@ class ComposeOrchestrator:
                     dockerfile_path=dockerfile_path,
                     image_name=image_name,
                     scan_only=self.scan_only,
-                    skip_ai_scoring=self.skip_ai_scoring
+                    skip_ai_scoring=self.skip_ai_scoring,
+                    scanner=self.vuln_scanner,
                 )
                 
                 # Disable cache for service scans to ensure fresh results?

--- a/docksec/docker_scanner.py
+++ b/docksec/docker_scanner.py
@@ -83,6 +83,12 @@ class ScanResultsCache:
             logger.info(f"Cleared {len(keys_to_delete)} old cache entries")
 
 class DockerSecurityScanner:
+    @property
+    def _cache_key(self) -> str:
+        """Cache key incorporating image name and scanner mode to prevent cross-scanner hits."""
+        scanner_mode = getattr(self, 'scanner', 'trivy')
+        return f"{self.image_name}[{scanner_mode}]"
+
     @staticmethod
     def _validate_file_path(file_path: str) -> Path:
         """
@@ -170,34 +176,36 @@ class DockerSecurityScanner:
         
         return ','.join(severity_list)
     
-    def _print_compact_vulnerability_summary(self, vulnerabilities: List[Dict]) -> None:
+    def _print_compact_vulnerability_summary(self, vulnerabilities: List[Dict], label: str = "") -> None:
         """
         Print a compact summary of vulnerabilities without full details.
         Shows count by severity in a single-line format.
-        
+
         Args:
             vulnerabilities: List of vulnerability dictionaries
+            label: Optional prefix label (e.g. "[Trivy]", "[Grype]")
         """
+        prefix = f"{label} " if label else ""
         if not vulnerabilities:
-            print("[SUCCESS] No vulnerabilities found.")
+            print(f"  {prefix}[SUCCESS] No vulnerabilities found.")
             return
-        
+
         severity_counts = defaultdict(int)
         for vuln in vulnerabilities:
             severity = vuln.get('Severity', Severity.UNKNOWN)
             severity_counts[severity] += 1
-        
+
         # Print compact single-line summary
         total = sum(severity_counts.values())
         severity_order = [Severity.CRITICAL, Severity.HIGH, Severity.MEDIUM, Severity.LOW]
         summary_parts = []
-        
+
         for severity in severity_order:
             count = severity_counts.get(severity, 0)
             if count > 0:
                 summary_parts.append(f"{severity}: {count}")
-        
-        print(f"  [VULNERABILITIES] {' | '.join(summary_parts)} | Total: {total}")
+
+        print(f"  {prefix}[VULNERABILITIES] {' | '.join(summary_parts)} | Total: {total}")
         
         # Show top 3 critical/high only
         critical_high = [v for v in vulnerabilities if v.get('Severity') in [Severity.CRITICAL, Severity.HIGH]]
@@ -209,7 +217,7 @@ class DockerSecurityScanner:
                     title = title[:57] + "..."
                 print(f"    • [{vuln.get('Severity')}] {vuln.get('VulnerabilityID', 'N/A')}: {title}")
     
-    def __init__(self, dockerfile_path: Optional[str], image_name: Optional[str], results_dir: str = RESULTS_DIR, scan_only: bool = False, skip_ai_scoring: bool = False):
+    def __init__(self, dockerfile_path: Optional[str], image_name: Optional[str], results_dir: str = RESULTS_DIR, scan_only: bool = False, skip_ai_scoring: bool = False, scanner: str = "trivy"):
         """
         Initialize the Docker Security Scanner with a Dockerfile path and/or image name.
         Verifies that required tools are installed and the specified files exist.
@@ -231,7 +239,13 @@ class DockerSecurityScanner:
             self.dockerfile_path = str(validated_path)
         else:
             self.dockerfile_path = None
-        
+
+        # Validate scanner choice
+        valid_scanners = ("trivy", "grype", "all")
+        if scanner not in valid_scanners:
+            raise ValueError(f"Invalid scanner: '{scanner}'. Valid options: {valid_scanners}")
+        self.scanner = scanner
+
         self.required_tools = ['trivy']
         if self.image_name:
             self.required_tools.append('docker')
@@ -284,7 +298,30 @@ class DockerSecurityScanner:
             for tool in missing_tools:
                 error_msg += f"\n{tool.upper()}:\n{self._get_tool_installation_instructions(tool)}\n"
             raise ValueError(error_msg)
-        
+
+        # Check optional Grype availability (does not raise — Grype is optional)
+        if self.scanner in ("grype", "all"):
+            try:
+                subprocess.run(
+                    ["grype", "version"],
+                    capture_output=True,
+                    check=True,
+                    timeout=10,
+                    shell=False
+                )
+                self._grype_available = True
+            except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+                self._grype_available = False
+                if self.scanner == "grype":
+                    print("[WARNING] Grype not found. Falling back to Trivy.")
+                    print("[TIP] Install Grype: run docksec-setup or visit https://github.com/anchore/grype")
+                    self.scanner = "trivy"
+                else:
+                    print("[WARNING] Grype not found. Using Trivy only for --scanner all.")
+                    print("[TIP] Install Grype: run docksec-setup or visit https://github.com/anchore/grype")
+        else:
+            self._grype_available = False
+
         # Verify Dockerfile exists (after validation)
         if self.dockerfile_path and not os.path.exists(self.dockerfile_path):
             raise ValueError(f"Dockerfile not found at {self.dockerfile_path}")
@@ -330,7 +367,7 @@ class DockerSecurityScanner:
         """
         # Check cache first
         if self.use_cache:
-            cached = self.cache.get(self.image_name)
+            cached = self.cache.get(self._cache_key)
             if cached:
                 print(f"[INFO] Using cached scan results for {self.image_name} (scanned at {cached.get('timestamp', 'N/A')})")
                 print("[TIP] To bypass cache, set environment variable DOCKSEC_USE_CACHE=false")
@@ -357,15 +394,31 @@ class DockerSecurityScanner:
             'scan_mode': 'image_only'
         }
 
-        # Run image vulnerability scan
-        image_success, image_output = self.scan_image(severity)
-        results['image_scan']['success'] = image_success
-        results['image_scan']['output'] = image_output
+        scanner_mode = getattr(self, 'scanner', 'trivy')
+        trivy_data: List[Dict] = []
+        grype_data: List[Dict] = []
 
-        # Get JSON data for vulnerabilities
-        json_success, json_data = self.scan_image_json(severity)
-        if json_success:
-            results['json_data'] = json_data
+        if scanner_mode in ("trivy", "all"):
+            image_success, image_output = self.scan_image(severity)
+            results['image_scan']['success'] = image_success
+            results['image_scan']['output'] = image_output
+            trivy_success, trivy_data = self.scan_image_json(severity)
+            trivy_data = trivy_data or []
+
+        if scanner_mode in ("grype", "all") and getattr(self, '_grype_available', False):
+            grype_success, grype_data = self.scan_image_grype(severity)
+            grype_data = grype_data or []
+            if scanner_mode == "grype":
+                results['image_scan']['success'] = grype_success
+
+        if scanner_mode == "trivy":
+            results['json_data'] = trivy_data
+        elif scanner_mode == "grype":
+            results['json_data'] = grype_data
+        else:  # "all"
+            results['json_data'] = self._deduplicate_vulnerabilities(trivy_data, grype_data)
+
+        json_data = results['json_data']
 
         # Cache results
         if self.use_cache:
@@ -375,11 +428,7 @@ class DockerSecurityScanner:
         if not json_data:
             print(f"[SUCCESS] Image scan completed for {self.image_name} (no vulnerabilities found).")
         else:
-            severity_counts = defaultdict(int)
-            for v in json_data:
-                severity_counts[v.get('Severity', Severity.UNKNOWN)] += 1
             print(f"[INFO] Image scan completed for {self.image_name}. Found {len(json_data)} vulnerabilities.")
-            # self._print_compact_vulnerability_summary(json_data) is already called in scan_image_json
 
         return results 
           
@@ -421,6 +470,13 @@ class DockerSecurityScanner:
                 "  - Linux: curl -L -o hadolint https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64 && chmod +x hadolint && sudo mv hadolint /usr/local/bin/\n"
                 "  - macOS: brew install hadolint\n"
                 "  - Windows: See https://github.com/hadolint/hadolint#install\n"
+                "  - Or run: python setup_external_tools.py"
+            ),
+            'grype': (
+                "Grype is an optional vulnerability scanner (complements Trivy). Install it:\n"
+                "  - Linux/Mac: curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin\n"
+                "  - macOS: brew install anchore/grype/grype\n"
+                "  - Windows: See https://github.com/anchore/grype#installation\n"
                 "  - Or run: python setup_external_tools.py"
             )
         }
@@ -527,6 +583,192 @@ class DockerSecurityScanner:
         
         return filtered_vulnerabilities
     
+    def _parse_grype_output(self, json_output: str, severity_filter: Optional[set] = None) -> List[Dict]:
+        """
+        Normalize Grype JSON output to DockSec's internal vulnerability format.
+
+        Args:
+            json_output: Raw JSON string from Grype
+            severity_filter: Set of uppercase severity levels to include (e.g. {"CRITICAL","HIGH"}).
+                             If None, all severities are included.
+
+        Returns:
+            List of normalized vulnerability dicts matching DockSec's internal schema.
+        """
+        try:
+            data = json.loads(json_output)
+        except json.JSONDecodeError:
+            return []
+
+        filtered_vulnerabilities = []
+
+        for match in data.get("matches", []):
+            vuln = match.get("vulnerability", {})
+            artifact = match.get("artifact", {})
+
+            # Grype uses title-case severity (e.g. "High") — normalize to upper
+            severity = vuln.get("severity", "UNKNOWN").upper()
+
+            # Apply severity filter
+            if severity_filter and severity not in severity_filter:
+                continue
+
+            raw_desc = vuln.get("description", "")
+            # Derive a concise title: use first sentence of description (≤100 chars)
+            if raw_desc:
+                first_sentence = raw_desc.split(".")[0].strip()
+                title = first_sentence[:100] + ("..." if len(first_sentence) > 100 else "")
+            else:
+                title = vuln.get("id", "")
+
+            description = raw_desc[:150] + "..." if len(raw_desc) > 150 else raw_desc
+
+            # Extract CVSS v3 base score — prefer NVD v3, fall back to any v3 entry
+            cvss_score = None
+            for cvss_entry in vuln.get("cvss", []):
+                version = str(cvss_entry.get("version", ""))
+                if version.startswith("3"):
+                    score = cvss_entry.get("metrics", {}).get("baseScore")
+                    if score is not None:
+                        cvss_score = score
+                        break
+
+            urls = vuln.get("urls", [])
+            primary_url = urls[0] if urls else None
+
+            fix_state = vuln.get("fix", {}).get("state", "")
+            status = "fixed" if fix_state == "fixed" else "affected"
+
+            # Use artifact locations for Target (mirrors Trivy's layer-level target)
+            locations = artifact.get("locations", [])
+            target = locations[0].get("path", "") if locations else artifact.get("type", "")
+
+            filtered_vulnerabilities.append({
+                "VulnerabilityID": vuln.get("id"),
+                "Target": target,
+                "PkgName": artifact.get("name", ""),
+                "InstalledVersion": artifact.get("version", ""),
+                "Severity": severity,
+                "Title": title,
+                "Description": description,
+                "Status": status,
+                "CVSS": cvss_score,
+                "PrimaryURL": primary_url,
+                "sources": ["grype"],
+            })
+
+        return filtered_vulnerabilities
+
+    def _deduplicate_vulnerabilities(self, trivy_vulns: List[Dict], grype_vulns: List[Dict]) -> List[Dict]:
+        """
+        Merge and deduplicate vulnerabilities from Trivy and Grype by CVE ID.
+
+        CVEs found by both scanners are merged into a single entry with
+        ``sources`` listing both tools.  CVEs found by only one scanner
+        keep their original data.
+
+        Args:
+            trivy_vulns: Normalized vulnerabilities from Trivy
+            grype_vulns: Normalized vulnerabilities from Grype
+
+        Returns:
+            Deduplicated list of vulnerability dicts with a ``sources`` field.
+        """
+        # Tag Trivy vulns with their source
+        for v in trivy_vulns:
+            v.setdefault("sources", ["trivy"])
+
+        seen: Dict[str, Dict] = {}
+
+        for v in trivy_vulns:
+            cve_id = v.get("VulnerabilityID")
+            if cve_id:
+                seen[cve_id] = v
+
+        for v in grype_vulns:
+            cve_id = v.get("VulnerabilityID")
+            if not cve_id:
+                continue
+            if cve_id in seen:
+                existing_sources = seen[cve_id].get("sources", ["trivy"])
+                if "grype" not in existing_sources:
+                    seen[cve_id]["sources"] = existing_sources + ["grype"]
+            else:
+                seen[cve_id] = v
+
+        return list(seen.values())
+
+    def scan_image_grype(self, severity: str = "CRITICAL,HIGH") -> Tuple[bool, Optional[List[Dict]]]:
+        """
+        Scan Docker image using Grype and return structured results.
+
+        Args:
+            severity: Comma-separated list of severity levels to include
+
+        Returns:
+            Tuple of (success: bool, vulnerabilities: List[Dict] | None)
+        """
+        from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TimeElapsedColumn
+
+        severity = self._validate_severity(severity)
+        severity_set = {s.strip().upper() for s in severity.split(",")}
+        logger.info(f"Starting Grype scan for image: {self.image_name}")
+
+        try:
+            with Progress(
+                SpinnerColumn(),
+                TextColumn("[progress.description]{task.description}"),
+                BarColumn(),
+                TimeElapsedColumn(),
+                console=None,
+            ) as progress:
+                scan_task = progress.add_task(
+                    f"[cyan]Scanning {self.image_name} with Grype...",
+                    total=None,
+                )
+
+                result = subprocess.run(
+                    [
+                        "grype",
+                        self.image_name,
+                        "-o", "json",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    timeout=600,
+                    shell=False,
+                )
+
+                progress.update(scan_task, completed=True)
+
+            if result.returncode != 0 and not result.stdout:
+                print(f"[ERROR] Grype scan failed: {result.stderr[:200]}")
+                return False, None
+
+            if not result.stdout:
+                return True, []
+
+            filtered_results = self._parse_grype_output(result.stdout, severity_set)
+            self._print_compact_vulnerability_summary(filtered_results, label="[Grype]")
+            return True, filtered_results
+
+        except subprocess.TimeoutExpired:
+            error_msg = "Grype scan timed out after 600 seconds"
+            logger.error(error_msg)
+            print(f"[ERROR] {error_msg}")
+            return False, None
+        except json.JSONDecodeError as e:
+            error_msg = f"Failed to parse Grype output: {e}"
+            logger.error(error_msg)
+            print(f"[ERROR] {error_msg}")
+            return False, None
+        except (subprocess.CalledProcessError, Exception) as e:
+            error_msg = f"Grype scan failed: {e}"
+            logger.error(error_msg, exc_info=True)
+            print(f"[ERROR] {error_msg}")
+            return False, None
+
     def scan_image_json(self, severity: str = "CRITICAL,HIGH") -> Tuple[bool, Optional[List[Dict]]]:
         """
         Scan Docker image using Trivy and return the results as structured data (compact).
@@ -586,10 +828,10 @@ class DockerSecurityScanner:
 
             response = json.loads(result.stdout)
             filtered_results = self._filter_scan_results(response)
-            
+
             # Print compact summary
-            self._print_compact_vulnerability_summary(filtered_results)
-                
+            self._print_compact_vulnerability_summary(filtered_results, label="[Trivy]")
+
             return True, filtered_results
             
         except subprocess.TimeoutExpired:
@@ -716,7 +958,7 @@ class DockerSecurityScanner:
         """
         # Check cache first (only if image name is provided)
         if self.image_name and self.use_cache:
-            cached = self.cache.get(self.image_name)
+            cached = self.cache.get(self._cache_key)
             if cached:
                 print(f"[INFO] Using cached scan results for {self.image_name} (scanned at {cached.get('timestamp', 'N/A')})")
                 print("[TIP] To bypass cache, set environment variable DOCKSEC_USE_CACHE=false")
@@ -755,21 +997,38 @@ class DockerSecurityScanner:
 
         # Run image vulnerability scan (only if image name is provided)
         if self.image_name:
-            image_success, image_output = self.scan_image(severity)
-            results['image_scan']['success'] = image_success
-            results['image_scan']['output'] = image_output
-            results['image_scan']['skipped'] = False
-            if not image_success:
-                scan_status = False
+            scanner_mode = getattr(self, 'scanner', 'trivy')
+            trivy_data: List[Dict] = []
+            grype_data: List[Dict] = []
 
-            # Get JSON data
-            json_success, json_data = self.scan_image_json(severity)
-            if json_success:
-                results['json_data'] = json_data
+            if scanner_mode in ("trivy", "all"):
+                image_success, image_output = self.scan_image(severity)
+                results['image_scan']['success'] = image_success
+                results['image_scan']['output'] = image_output
+                results['image_scan']['skipped'] = False
+                if not image_success:
+                    scan_status = False
+                trivy_success, trivy_data = self.scan_image_json(severity)
+                trivy_data = trivy_data or []
+
+            if scanner_mode in ("grype", "all") and getattr(self, '_grype_available', False):
+                grype_success, grype_data = self.scan_image_grype(severity)
+                grype_data = grype_data or []
+                if not grype_success and scanner_mode == "grype":
+                    scan_status = False
+                    results['image_scan']['skipped'] = False
+
+            if scanner_mode == "trivy":
+                results['json_data'] = trivy_data
+            elif scanner_mode == "grype":
+                results['image_scan']['skipped'] = False
+                results['json_data'] = grype_data
+            else:  # "all"
+                results['json_data'] = self._deduplicate_vulnerabilities(trivy_data, grype_data)
 
             # Cache results
             if self.use_cache:
-                self.cache.set(self.image_name, results)
+                self.cache.set(self._cache_key, results)
 
         # Print final summary
         target_name = self.image_name if self.image_name else self.dockerfile_path
@@ -837,17 +1096,23 @@ class DockerSecurityScanner:
         try:
             # Define CSV columns
             fieldnames = [
-                "VulnerabilityID", "Severity", "PkgName", "InstalledVersion", 
-                "Title", "Description", "CVSS", "Status", "Target", "PrimaryURL"
+                "VulnerabilityID", "Severity", "PkgName", "InstalledVersion",
+                "Title", "Description", "CVSS", "Status", "Target", "PrimaryURL",
+                "sources",
             ]
-            
+
             with open(output_file, 'w', newline='') as csvfile:
                 writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
                 writer.writeheader()
-                
+
                 for vuln in vulnerabilities:
-                    # Only write the fields we care about
-                    filtered_vuln = {k: vuln.get(k, "") for k in fieldnames}
+                    filtered_vuln = {}
+                    for k in fieldnames:
+                        v = vuln.get(k, "")
+                        # Serialize list fields (e.g. sources) to comma-separated string
+                        if isinstance(v, list):
+                            v = ",".join(str(x) for x in v)
+                        filtered_vuln[k] = v
                     writer.writerow(filtered_vuln)
                     
             return output_file

--- a/docksec/report_generator.py
+++ b/docksec/report_generator.py
@@ -95,6 +95,7 @@ class ReportGenerator:
         logger.info(f"Generating JSON report: {output_file}")
 
         json_results = results.get("json_data", [])
+        coverage = self._build_scanner_coverage(json_results)
         report_data = {
             "scan_info": {
                 "image": self.image_name,
@@ -104,9 +105,11 @@ class ReportGenerator:
                 ),
                 "analysis_score": self.analysis_score,
                 "scan_mode": results.get("scan_mode", "full"),
+                "scanners_used": coverage["scanners_used"],
             },
             "vulnerabilities": json_results,
             "severity_counts": self._count_by_severity(json_results),
+            "scanner_coverage": coverage,
         }
         
         # Add AI findings if available
@@ -158,6 +161,7 @@ class ReportGenerator:
                 "Status": "Status",
                 "Target": "Target",
                 "PrimaryURL": "URL",
+                "sources": "Sources",
             }
 
             with open(output_file, "w", newline="") as csvfile:
@@ -167,7 +171,13 @@ class ReportGenerator:
                 writer.writeheader()
 
                 for vuln in vulnerabilities:
-                    row = {header_mapping[k]: vuln.get(k, "") for k in header_mapping}
+                    row = {}
+                    for internal_key, csv_header in header_mapping.items():
+                        value = vuln.get(internal_key, "")
+                        # Serialize list fields (e.g. sources) to comma-separated string
+                        if isinstance(value, list):
+                            value = ",".join(str(x) for x in value)
+                        row[csv_header] = value
                     writer.writerow(row)
 
             logger.info(
@@ -619,6 +629,7 @@ class ReportGenerator:
             template_vars["VULNERABILITY_SUMMARY"] = (
                 '<div class="no-issues">No vulnerabilities found</div>'
             )
+            template_vars["SCANNER_COVERAGE_SECTION"] = ""
             template_vars["DETAILED_VULNERABILITIES_SECTION"] = ""
         else:
             severity_counts = self._count_by_severity(vulnerabilities)
@@ -647,7 +658,12 @@ class ReportGenerator:
 
             template_vars["VULNERABILITY_SUMMARY"] = severity_html
 
-            # Detailed vulnerabilities table
+            # Scanner Coverage Section
+            template_vars["SCANNER_COVERAGE_SECTION"] = self._build_scanner_coverage_html(
+                vulnerabilities
+            )
+
+            # Detailed vulnerabilities table — includes Scanner column
             table_html = """
             <div class="section">
                 <h2>Detailed Vulnerabilities</h2>
@@ -661,6 +677,7 @@ class ReportGenerator:
                             <th>Title</th>
                             <th>CVSS</th>
                             <th>Status</th>
+                            <th>Scanner</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -687,6 +704,8 @@ class ReportGenerator:
                         else str(cvss_score)
                     )
 
+                scanner_badge = self._get_scanner_badge_html(vuln)
+
                 table_html += f"""
                         <tr>
                             <td><strong>{self._escape_html(vuln.get('VulnerabilityID', 'N/A'))}</strong></td>
@@ -696,6 +715,7 @@ class ReportGenerator:
                             <td>{self._escape_html((vuln.get('Title', '')[:80] + '...') if len(vuln.get('Title', '')) > 80 else vuln.get('Title', 'N/A'))}</td>
                             <td>{cvss_score}</td>
                             <td><span class="status-badge {status_class}">{status}</span></td>
+                            <td>{scanner_badge}</td>
                         </tr>
                 """
 
@@ -730,6 +750,136 @@ class ReportGenerator:
         if not text:
             return ""
         return html.escape(str(text), quote=True)
+
+    def _build_scanner_coverage(self, vulnerabilities: List[Dict]) -> Dict:
+        """
+        Compute scanner coverage statistics from the vulnerability list.
+
+        Args:
+            vulnerabilities: Normalized vulnerability dicts (may contain a ``sources`` field)
+
+        Returns:
+            Dictionary with keys: total, trivy_only, grype_only, confirmed_by_both, scanners_used
+        """
+        trivy_only = 0
+        grype_only = 0
+        both = 0
+        scanners_seen: set = set()
+
+        for v in vulnerabilities:
+            sources = v.get("sources")
+            if not sources:
+                # No source tag → assumed to be from Trivy (backward compat)
+                trivy_only += 1
+                scanners_seen.add("trivy")
+                continue
+
+            if isinstance(sources, str):
+                sources = [s.strip().lower() for s in sources.split(",")]
+            else:
+                sources = [s.lower() for s in sources]
+
+            sources_set = set(sources)
+            scanners_seen.update(sources_set)
+
+            has_trivy = "trivy" in sources_set
+            has_grype = "grype" in sources_set
+
+            if has_trivy and has_grype:
+                both += 1
+            elif has_grype:
+                grype_only += 1
+            else:
+                trivy_only += 1
+
+        return {
+            "total": len(vulnerabilities),
+            "trivy_only": trivy_only,
+            "grype_only": grype_only,
+            "confirmed_by_both": both,
+            "scanners_used": sorted(list(scanners_seen)) if scanners_seen else ["trivy"],
+        }
+
+    def _build_scanner_coverage_html(self, vulnerabilities: List[Dict]) -> str:
+        """
+        Build the HTML Scanner Coverage section for the report.
+
+        Args:
+            vulnerabilities: Normalized vulnerability dicts
+
+        Returns:
+            HTML string for the scanner coverage section, or empty string if no vulns
+        """
+        coverage = self._build_scanner_coverage(vulnerabilities)
+        scanners_display = " + ".join(s.capitalize() for s in coverage["scanners_used"])
+
+        if not vulnerabilities:
+            return ""
+
+        # Only show detailed grid when more than one scanner was used
+        multi_scanner = len(coverage["scanners_used"]) > 1
+
+        grid_html = ""
+        if multi_scanner:
+            grid_html = f"""
+            <div class="coverage-grid">
+                <div class="coverage-item coverage-total">
+                    <div class="coverage-count">{coverage["total"]}</div>
+                    <div class="coverage-label">Total CVEs</div>
+                </div>
+                <div class="coverage-item coverage-trivy">
+                    <div class="coverage-count">{coverage["trivy_only"]}</div>
+                    <div class="coverage-label">Trivy Only</div>
+                </div>
+                <div class="coverage-item coverage-grype">
+                    <div class="coverage-count">{coverage["grype_only"]}</div>
+                    <div class="coverage-label">Grype Only</div>
+                </div>
+                <div class="coverage-item coverage-both">
+                    <div class="coverage-count">{coverage["confirmed_by_both"]}</div>
+                    <div class="coverage-label">Confirmed by Both</div>
+                </div>
+            </div>
+            """
+
+        return f"""
+        <div class="section" style="border-left-color: #9b59b6;">
+            <h2>Scanner Coverage</h2>
+            <p class="scanners-used-row">
+                Scanners used: <strong>{self._escape_html(scanners_display)}</strong>
+            </p>
+            {grid_html}
+        </div>
+        """
+
+    def _get_scanner_badge_html(self, vuln: Dict) -> str:
+        """
+        Return an HTML scanner badge for a single vulnerability row.
+
+        Args:
+            vuln: Vulnerability dict (may contain a ``sources`` field)
+
+        Returns:
+            HTML span string for the scanner badge
+        """
+        sources = vuln.get("sources")
+        if not sources:
+            return '<span class="scanner-badge scanner-trivy">Trivy</span>'
+
+        if isinstance(sources, str):
+            sources = [s.strip().lower() for s in sources.split(",")]
+        else:
+            sources = [s.lower() for s in sources]
+
+        sources_set = set(sources)
+        has_trivy = "trivy" in sources_set
+        has_grype = "grype" in sources_set
+
+        if has_trivy and has_grype:
+            return '<span class="scanner-badge scanner-both">Both</span>'
+        if has_grype:
+            return '<span class="scanner-badge scanner-grype">Grype</span>'
+        return '<span class="scanner-badge scanner-trivy">Trivy</span>'
 
     def _count_by_severity(self, vulnerabilities: List[Dict]) -> Dict[str, int]:
         """

--- a/docksec/setup_external_tools.py
+++ b/docksec/setup_external_tools.py
@@ -164,10 +164,78 @@ def install_trivy():
         print(f"Error installing Trivy: {str(e)}")
         return False
 
+def install_grype():
+    """Install Grype vulnerability scanner based on the operating system."""
+    os_type = get_os_type()
+
+    if check_command_exists("grype"):
+        success, version = run_command(["grype", "version"])
+        if success:
+            print(f"Grype is already installed: {version.strip()}")
+            return True
+
+    print("Installing Grype...")
+
+    try:
+        if os_type == "mac":
+            success, _ = run_command(["brew", "install", "anchore/grype/grype"])
+            if not success:
+                print("Please install Homebrew first: https://brew.sh")
+                return False
+
+        elif os_type == "linux":
+            # Use the official Grype install script
+            install_script_cmd = (
+                "curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh"
+                " | sh -s -- -b /usr/local/bin"
+            )
+            success, _ = run_command(install_script_cmd, shell=True)
+            if not success:
+                print("Failed to install Grype via install script.")
+                return False
+
+        elif os_type == "windows":
+            # Fetch the latest release tag from GitHub
+            try:
+                url = "https://api.github.com/repos/anchore/grype/releases/latest"
+                with urllib.request.urlopen(url) as response:
+                    data = json.loads(response.read().decode())
+                    version_tag = data["tag_name"].lstrip("v")
+            except Exception as e:
+                print(f"Failed to get latest Grype version: {e}")
+                return False
+
+            install_dir = Path(os.environ.get("USERPROFILE", "")) / "grype"
+            install_dir.mkdir(parents=True, exist_ok=True)
+
+            zip_url = (
+                f"https://github.com/anchore/grype/releases/download/v{version_tag}/"
+                f"grype_{version_tag}_windows_amd64.zip"
+            )
+            zip_path = install_dir / "grype.zip"
+            urllib.request.urlretrieve(zip_url, str(zip_path))
+
+            with zipfile.ZipFile(str(zip_path), "r") as zip_ref:
+                zip_ref.extractall(str(install_dir))
+            zip_path.unlink()
+
+            user_path = os.environ.get("PATH", "")
+            if str(install_dir) not in user_path:
+                subprocess.run(["setx", "PATH", f"{user_path};{install_dir}"], shell=True)
+                print("Added Grype to PATH. Please restart your terminal.")
+
+        print("Grype installed successfully!")
+        return True
+
+    except Exception as e:
+        print(f"Error installing Grype: {str(e)}")
+        return False
+
+
 def main():
     """Main function to install and verify tools."""
     print("Checking and installing required tools...")
-    
+
     # Install Hadolint
     print("\nChecking Hadolint...")
     if install_hadolint():
@@ -185,6 +253,15 @@ def main():
             print(f"Trivy version: {version.strip()}")
     else:
         print("Failed to install Trivy")
+
+    # Install Grype
+    print("\nChecking Grype...")
+    if install_grype():
+        success, version = run_command(["grype", "version"])
+        if success:
+            print(f"Grype version: {version.strip()}")
+    else:
+        print("Failed to install Grype")
 
 if __name__ == "__main__":
     main()

--- a/docksec/templates/report_template.html
+++ b/docksec/templates/report_template.html
@@ -347,7 +347,82 @@
         .config-list.low li {
             border-left-color: #f1c40f;
         }
-        
+
+        /* Scanner badges */
+        .scanner-badge {
+            display: inline-block;
+            padding: 3px 9px;
+            border-radius: 12px;
+            font-size: 0.75em;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.3px;
+        }
+
+        .scanner-trivy {
+            background: #e3f2fd;
+            color: #1565c0;
+            border: 1px solid #90caf9;
+        }
+
+        .scanner-grype {
+            background: #e8f5e9;
+            color: #2e7d32;
+            border: 1px solid #a5d6a7;
+        }
+
+        .scanner-both {
+            background: #fce4ec;
+            color: #c62828;
+            border: 1px solid #ef9a9a;
+        }
+
+        /* Scanner coverage section */
+        .coverage-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+            gap: 16px;
+            margin-top: 20px;
+        }
+
+        .coverage-item {
+            text-align: center;
+            padding: 20px 12px;
+            border-radius: 10px;
+            background: white;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+            border-top: 4px solid #ccc;
+        }
+
+        .coverage-total { border-top-color: #607d8b; }
+        .coverage-trivy { border-top-color: #1565c0; }
+        .coverage-grype { border-top-color: #2e7d32; }
+        .coverage-both  { border-top-color: #c62828; }
+
+        .coverage-count {
+            font-size: 2em;
+            font-weight: 700;
+            margin-bottom: 4px;
+        }
+
+        .coverage-total .coverage-count { color: #607d8b; }
+        .coverage-trivy .coverage-count { color: #1565c0; }
+        .coverage-grype .coverage-count { color: #2e7d32; }
+        .coverage-both  .coverage-count { color: #c62828; }
+
+        .coverage-label {
+            font-size: 0.8em;
+            color: #666;
+            text-transform: uppercase;
+            letter-spacing: 0.4px;
+        }
+
+        .scanners-used-row {
+            margin-top: 15px;
+            font-size: 0.92em;
+            color: #444;
+        }
+
         @media (max-width: 768px) {
             .container {
                 margin: 10px;
@@ -437,6 +512,9 @@
                 <h2>Vulnerability Summary</h2>
                 {{VULNERABILITY_SUMMARY}}
             </div>
+
+            <!-- Scanner Coverage Section -->
+            {{SCANNER_COVERAGE_SECTION}}
 
             <!-- Detailed Vulnerabilities Section -->
             {{DETAILED_VULNERABILITIES_SECTION}}

--- a/tests/test_docker_scanner.py
+++ b/tests/test_docker_scanner.py
@@ -514,6 +514,399 @@ class TestDockerSecurityScanner(unittest.TestCase):
             self.assertEqual(score, 85.5)
 
 
+    # ------------------------------------------------------------------
+    # Grype: _parse_grype_output
+    # ------------------------------------------------------------------
+
+    def _make_grype_match(self, cve_id="CVE-2024-1234", severity="High",
+                          pkg_name="libssl", version="1.0.0"):
+        """Return a minimal Grype match dict."""
+        return {
+            "vulnerability": {
+                "id": cve_id,
+                "severity": severity,
+                "description": "A test vulnerability",
+                "urls": [f"https://nvd.nist.gov/vuln/detail/{cve_id}"],
+                "cvss": [{"version": "3.1", "metrics": {"baseScore": 7.5}}],
+                "fix": {"state": "fixed"},
+            },
+            "artifact": {
+                "name": pkg_name,
+                "version": version,
+                "type": "deb",
+                "locations": [{"path": "/usr/lib/libssl.so"}],
+            },
+        }
+
+    def test_parse_grype_output_with_vulns(self):
+        """Test _parse_grype_output with a normal Grype JSON payload."""
+        from docksec.docker_scanner import DockerSecurityScanner
+
+        scanner = DockerSecurityScanner.__new__(DockerSecurityScanner)
+        payload = json.dumps({"matches": [self._make_grype_match()]})
+
+        results = scanner._parse_grype_output(payload)
+        self.assertEqual(len(results), 1)
+        vuln = results[0]
+        self.assertEqual(vuln["VulnerabilityID"], "CVE-2024-1234")
+        self.assertEqual(vuln["Severity"], "HIGH")
+        self.assertEqual(vuln["PkgName"], "libssl")
+        self.assertEqual(vuln["InstalledVersion"], "1.0.0")
+        self.assertEqual(vuln["Status"], "fixed")
+        self.assertAlmostEqual(vuln["CVSS"], 7.5)
+        self.assertEqual(vuln["sources"], ["grype"])
+
+    def test_parse_grype_output_empty_matches(self):
+        """Test _parse_grype_output with no matches."""
+        from docksec.docker_scanner import DockerSecurityScanner
+
+        scanner = DockerSecurityScanner.__new__(DockerSecurityScanner)
+        payload = json.dumps({"matches": []})
+        results = scanner._parse_grype_output(payload)
+        self.assertEqual(results, [])
+
+    def test_parse_grype_output_severity_filter(self):
+        """Test that _parse_grype_output filters by severity."""
+        from docksec.docker_scanner import DockerSecurityScanner
+
+        scanner = DockerSecurityScanner.__new__(DockerSecurityScanner)
+        payload = json.dumps({
+            "matches": [
+                self._make_grype_match(cve_id="CVE-HIGH", severity="High"),
+                self._make_grype_match(cve_id="CVE-LOW", severity="Low"),
+            ]
+        })
+
+        results = scanner._parse_grype_output(payload, severity_filter={"HIGH"})
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["VulnerabilityID"], "CVE-HIGH")
+
+    def test_parse_grype_output_invalid_json(self):
+        """Test that _parse_grype_output handles invalid JSON gracefully."""
+        from docksec.docker_scanner import DockerSecurityScanner
+
+        scanner = DockerSecurityScanner.__new__(DockerSecurityScanner)
+        results = scanner._parse_grype_output("not valid json")
+        self.assertEqual(results, [])
+
+    # ------------------------------------------------------------------
+    # Grype: _deduplicate_vulnerabilities
+    # ------------------------------------------------------------------
+
+    def test_deduplicate_vulnerabilities_no_overlap(self):
+        """Test deduplication when Trivy and Grype find different CVEs."""
+        from docksec.docker_scanner import DockerSecurityScanner
+
+        scanner = DockerSecurityScanner.__new__(DockerSecurityScanner)
+        trivy = [{"VulnerabilityID": "CVE-001", "Severity": "HIGH"}]
+        grype = [{"VulnerabilityID": "CVE-002", "Severity": "CRITICAL", "sources": ["grype"]}]
+
+        merged = scanner._deduplicate_vulnerabilities(trivy, grype)
+        ids = {v["VulnerabilityID"] for v in merged}
+        self.assertEqual(ids, {"CVE-001", "CVE-002"})
+
+    def test_deduplicate_vulnerabilities_with_overlap(self):
+        """Test deduplication merges sources when both scanners find the same CVE."""
+        from docksec.docker_scanner import DockerSecurityScanner
+
+        scanner = DockerSecurityScanner.__new__(DockerSecurityScanner)
+        trivy = [{"VulnerabilityID": "CVE-001", "Severity": "HIGH"}]
+        grype = [{"VulnerabilityID": "CVE-001", "Severity": "HIGH", "sources": ["grype"]}]
+
+        merged = scanner._deduplicate_vulnerabilities(trivy, grype)
+        self.assertEqual(len(merged), 1)
+        self.assertIn("trivy", merged[0]["sources"])
+        self.assertIn("grype", merged[0]["sources"])
+
+    def test_deduplicate_vulnerabilities_empty_inputs(self):
+        """Test deduplication with empty lists."""
+        from docksec.docker_scanner import DockerSecurityScanner
+
+        scanner = DockerSecurityScanner.__new__(DockerSecurityScanner)
+        self.assertEqual(scanner._deduplicate_vulnerabilities([], []), [])
+        trivy = [{"VulnerabilityID": "CVE-001", "Severity": "HIGH"}]
+        result = scanner._deduplicate_vulnerabilities(trivy, [])
+        self.assertEqual(len(result), 1)
+
+    # ------------------------------------------------------------------
+    # Grype: scan_image_grype
+    # ------------------------------------------------------------------
+
+    @patch('docksec.docker_scanner.subprocess.run')
+    def test_scan_image_grype_success(self, mock_run):
+        """Test a successful Grype scan."""
+        from docksec.docker_scanner import DockerSecurityScanner
+
+        grype_json = json.dumps({
+            "matches": [{
+                "vulnerability": {
+                    "id": "CVE-2024-9999",
+                    "severity": "Critical",
+                    "description": "Test",
+                    "urls": [],
+                    "cvss": [],
+                    "fix": {"state": "unknown"},
+                },
+                "artifact": {
+                    "name": "openssl",
+                    "version": "1.1.1",
+                    "type": "deb",
+                    "locations": [],
+                },
+            }]
+        })
+        mock_run.return_value = Mock(returncode=0, stdout=grype_json, stderr="")
+
+        scanner = DockerSecurityScanner.__new__(DockerSecurityScanner)
+        scanner.image_name = "test:latest"
+
+        success, results = scanner.scan_image_grype()
+        self.assertTrue(success)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["VulnerabilityID"], "CVE-2024-9999")
+        self.assertEqual(results[0]["Severity"], "CRITICAL")
+
+    @patch('docksec.docker_scanner.subprocess.run')
+    def test_scan_image_grype_failure(self, mock_run):
+        """Test Grype scan failure returns (False, None)."""
+        from docksec.docker_scanner import DockerSecurityScanner
+
+        mock_run.return_value = Mock(returncode=1, stdout="", stderr="grype error")
+
+        scanner = DockerSecurityScanner.__new__(DockerSecurityScanner)
+        scanner.image_name = "test:latest"
+
+        success, results = scanner.scan_image_grype()
+        self.assertFalse(success)
+        self.assertIsNone(results)
+
+    @patch('docksec.docker_scanner.subprocess.run')
+    def test_run_full_scan_grype_mode(self, mock_run):
+        """Test run_full_scan routes correctly for scanner='grype'."""
+        from docksec.docker_scanner import DockerSecurityScanner
+
+        grype_json = json.dumps({
+            "matches": [{
+                "vulnerability": {
+                    "id": "CVE-2024-0001",
+                    "severity": "High",
+                    "description": "",
+                    "urls": [],
+                    "cvss": [],
+                    "fix": {"state": "unknown"},
+                },
+                "artifact": {
+                    "name": "curl", "version": "7.0", "type": "deb", "locations": [],
+                },
+            }]
+        })
+
+        with patch.object(DockerSecurityScanner, 'scan_dockerfile', return_value=(True, None)), \
+             patch.object(DockerSecurityScanner, 'scan_image_grype',
+                          return_value=(True, [{"VulnerabilityID": "CVE-2024-0001",
+                                                "Severity": "HIGH", "sources": ["grype"]}])):
+            scanner = DockerSecurityScanner.__new__(DockerSecurityScanner)
+            scanner.image_name = "test:latest"
+            scanner.dockerfile_path = "Dockerfile"
+            scanner.use_cache = False
+            scanner.scanner = "grype"
+            scanner._grype_available = True
+
+            results = scanner.run_full_scan()
+
+        self.assertEqual(len(results['json_data']), 1)
+        self.assertEqual(results['json_data'][0]['sources'], ["grype"])
+
+    # ------------------------------------------------------------------
+    # Grype title extraction
+    # ------------------------------------------------------------------
+
+    def test_parse_grype_output_title_from_description(self):
+        """_parse_grype_output derives title from first sentence of description."""
+        from docksec.docker_scanner import DockerSecurityScanner
+
+        scanner = DockerSecurityScanner.__new__(DockerSecurityScanner)
+        match = self._make_grype_match()
+        match["vulnerability"]["description"] = "Buffer overflow in libssl. Additional details here."
+        payload = json.dumps({"matches": [match]})
+
+        results = scanner._parse_grype_output(payload)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["Title"], "Buffer overflow in libssl")
+
+    def test_parse_grype_output_title_fallback_to_id(self):
+        """_parse_grype_output falls back to CVE ID when description is empty."""
+        from docksec.docker_scanner import DockerSecurityScanner
+
+        scanner = DockerSecurityScanner.__new__(DockerSecurityScanner)
+        match = self._make_grype_match(cve_id="CVE-2024-5678")
+        match["vulnerability"]["description"] = ""
+        payload = json.dumps({"matches": [match]})
+
+        results = scanner._parse_grype_output(payload)
+        self.assertEqual(results[0]["Title"], "CVE-2024-5678")
+
+    # ------------------------------------------------------------------
+    # Report generator: _build_scanner_coverage
+    # ------------------------------------------------------------------
+
+    def test_build_scanner_coverage_trivy_only(self):
+        """Coverage stats for Trivy-only results."""
+        from docksec.report_generator import ReportGenerator
+
+        gen = ReportGenerator.__new__(ReportGenerator)
+        vulns = [
+            {"VulnerabilityID": "CVE-001"},  # no sources tag → trivy
+            {"VulnerabilityID": "CVE-002", "sources": ["trivy"]},
+        ]
+        cov = gen._build_scanner_coverage(vulns)
+        self.assertEqual(cov["total"], 2)
+        self.assertEqual(cov["trivy_only"], 2)
+        self.assertEqual(cov["grype_only"], 0)
+        self.assertEqual(cov["confirmed_by_both"], 0)
+        self.assertEqual(cov["scanners_used"], ["trivy"])
+
+    def test_build_scanner_coverage_mixed(self):
+        """Coverage stats when both scanners contribute."""
+        from docksec.report_generator import ReportGenerator
+
+        gen = ReportGenerator.__new__(ReportGenerator)
+        vulns = [
+            {"VulnerabilityID": "CVE-001", "sources": ["trivy"]},
+            {"VulnerabilityID": "CVE-002", "sources": ["grype"]},
+            {"VulnerabilityID": "CVE-003", "sources": ["trivy", "grype"]},
+        ]
+        cov = gen._build_scanner_coverage(vulns)
+        self.assertEqual(cov["total"], 3)
+        self.assertEqual(cov["trivy_only"], 1)
+        self.assertEqual(cov["grype_only"], 1)
+        self.assertEqual(cov["confirmed_by_both"], 1)
+        self.assertIn("trivy", cov["scanners_used"])
+        self.assertIn("grype", cov["scanners_used"])
+
+    def test_build_scanner_coverage_empty(self):
+        """Coverage stats for an empty vulnerability list."""
+        from docksec.report_generator import ReportGenerator
+
+        gen = ReportGenerator.__new__(ReportGenerator)
+        cov = gen._build_scanner_coverage([])
+        self.assertEqual(cov["total"], 0)
+        self.assertEqual(cov["confirmed_by_both"], 0)
+
+    def test_get_scanner_badge_html_trivy(self):
+        """Badge for a Trivy-only vuln."""
+        from docksec.report_generator import ReportGenerator
+
+        gen = ReportGenerator.__new__(ReportGenerator)
+        badge = gen._get_scanner_badge_html({"sources": ["trivy"]})
+        self.assertIn("scanner-trivy", badge)
+        self.assertIn("Trivy", badge)
+
+    def test_get_scanner_badge_html_grype(self):
+        """Badge for a Grype-only vuln."""
+        from docksec.report_generator import ReportGenerator
+
+        gen = ReportGenerator.__new__(ReportGenerator)
+        badge = gen._get_scanner_badge_html({"sources": ["grype"]})
+        self.assertIn("scanner-grype", badge)
+        self.assertIn("Grype", badge)
+
+    def test_get_scanner_badge_html_both(self):
+        """Badge for a vuln confirmed by both scanners."""
+        from docksec.report_generator import ReportGenerator
+
+        gen = ReportGenerator.__new__(ReportGenerator)
+        badge = gen._get_scanner_badge_html({"sources": ["trivy", "grype"]})
+        self.assertIn("scanner-both", badge)
+        self.assertIn("Both", badge)
+
+    # ------------------------------------------------------------------
+    # DOCKSEC_SCANNER env var resolution
+    # ------------------------------------------------------------------
+
+    @patch('docksec.docker_scanner.subprocess.run')
+    @patch('docksec.docker_scanner.get_llm')
+    def test_init_scanner_param_default(self, mock_llm, mock_subprocess):
+        """DockerSecurityScanner defaults to scanner='trivy'."""
+        mock_subprocess.return_value = Mock(returncode=0, stdout="", stderr="")
+        mock_llm.return_value = Mock()
+
+        dockerfile = self.create_test_dockerfile()
+        from docksec.docker_scanner import DockerSecurityScanner
+
+        scanner = DockerSecurityScanner(dockerfile, None, scan_only=True)
+        self.assertEqual(scanner.scanner, "trivy")
+
+    @patch('docksec.docker_scanner.subprocess.run')
+    @patch('docksec.docker_scanner.get_llm')
+    def test_init_scanner_param_grype_unavailable_falls_back(self, mock_llm, mock_subprocess):
+        """When scanner='grype' but grype is not installed, falls back to trivy."""
+        # _check_tools() calls: trivy --version, hadolint --version (for dockerfile_path)
+        # Then grype version check.
+        mock_subprocess.side_effect = [
+            Mock(returncode=0, stdout="", stderr=""),   # trivy --version
+            Mock(returncode=0, stdout="", stderr=""),   # hadolint --version
+            FileNotFoundError(),                         # grype version check
+        ]
+        mock_llm.return_value = Mock()
+
+        dockerfile = self.create_test_dockerfile()
+        from docksec.docker_scanner import DockerSecurityScanner
+
+        scanner = DockerSecurityScanner(dockerfile, None, scan_only=True, scanner="grype")
+        # Should silently fall back to trivy
+        self.assertEqual(scanner.scanner, "trivy")
+        self.assertFalse(scanner._grype_available)
+
+    @patch('docksec.docker_scanner.subprocess.run')
+    @patch('docksec.docker_scanner.get_llm')
+    def test_init_scanner_param_invalid_raises(self, mock_llm, mock_subprocess):
+        """DockerSecurityScanner raises ValueError for unknown scanner name."""
+        mock_subprocess.return_value = Mock(returncode=0, stdout="", stderr="")
+        mock_llm.return_value = Mock()
+
+        dockerfile = self.create_test_dockerfile()
+        from docksec.docker_scanner import DockerSecurityScanner
+
+        with self.assertRaises(ValueError):
+            DockerSecurityScanner(dockerfile, None, scan_only=True, scanner="unknown_tool")
+
+    @patch('docksec.docker_scanner.DockerSecurityScanner.scan_dockerfile')
+    @patch('docksec.docker_scanner.DockerSecurityScanner.scan_image')
+    @patch('docksec.docker_scanner.DockerSecurityScanner.scan_image_json')
+    @patch('docksec.docker_scanner.DockerSecurityScanner.scan_image_grype')
+    def test_run_full_scan_all_mode_deduplication(
+        self, mock_grype, mock_json, mock_image, mock_dockerfile
+    ):
+        """Test run_full_scan deduplicates when scanner='all'."""
+        from docksec.docker_scanner import DockerSecurityScanner
+
+        mock_dockerfile.return_value = (True, None)
+        mock_image.return_value = (True, "output")
+        mock_json.return_value = (True, [
+            {"VulnerabilityID": "CVE-SHARED", "Severity": "HIGH"},
+            {"VulnerabilityID": "CVE-TRIVY-ONLY", "Severity": "HIGH"},
+        ])
+        mock_grype.return_value = (True, [
+            {"VulnerabilityID": "CVE-SHARED", "Severity": "HIGH", "sources": ["grype"]},
+            {"VulnerabilityID": "CVE-GRYPE-ONLY", "Severity": "CRITICAL", "sources": ["grype"]},
+        ])
+
+        scanner = DockerSecurityScanner.__new__(DockerSecurityScanner)
+        scanner.image_name = "test:latest"
+        scanner.dockerfile_path = "Dockerfile"
+        scanner.use_cache = False
+        scanner.scanner = "all"
+        scanner._grype_available = True
+
+        results = scanner.run_full_scan()
+        ids = {v["VulnerabilityID"] for v in results['json_data']}
+        self.assertEqual(ids, {"CVE-SHARED", "CVE-TRIVY-ONLY", "CVE-GRYPE-ONLY"})
+        shared = next(v for v in results['json_data'] if v["VulnerabilityID"] == "CVE-SHARED")
+        self.assertIn("trivy", shared["sources"])
+        self.assertIn("grype", shared["sources"])
+
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -102,6 +102,7 @@ def test_csv_header_row_is_correct(tmp_path, sample_vulnerabilities, sample_scan
         "Status",
         "Target",
         "URL",
+        "Sources",
     ]
     assert header == expected
 
@@ -141,6 +142,7 @@ def test_csv_empty_input_header_only(tmp_path, sample_scan_info):
         "Status",
         "Target",
         "URL",
+        "Sources",
     ]
     assert rows[0] == expected
 


### PR DESCRIPTION
Closes #50

- Add `install_grype()` to setup_external_tools.py (macOS/Linux/Windows)
- Add `--scanner {trivy,grype,all}` CLI flag and `DOCKSEC_SCANNER` env var
- Add `_parse_grype_output()` normalizing Grype JSON to DockSec's internal schema
- Add `_deduplicate_vulnerabilities()` merging Trivy + Grype by CVE ID with sources tracking
- Add `scan_image_grype()` method mirroring `scan_image_json()` interface
- Route `run_full_scan()` and `run_image_only_scan()` by scanner mode (trivy/grype/all)
- Add `_cache_key` property scoped to scanner mode to prevent cross-scanner cache hits
- Add Scanner Coverage section to HTML/JSON reports with per-CVE scanner badges
- Add `Sources` column to CSV reports; `scanner_coverage` object to JSON reports
- Pass `scanner` param through `ComposeOrchestrator` to all service scanners
- Update README with `--scanner` usage, env var, and comparison table row
- Add 21 new unit tests (46 total in test_docker_scanner.py, 99 total pass)
