### PR TITLE
Phase 1: terminal output overhaul - result summary, severity table, --quiet/--no-color

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,18 @@ docksec --image-only -i myapp:latest
 
 # Fast scan only (no AI)
 docksec Dockerfile --scan-only
+
+# Reduce output to warnings, errors, and the result summary
+docksec Dockerfile --scan-only --quiet
+
+# Disable colored output (also honors the NO_COLOR env var)
+docksec Dockerfile --no-color
 ```
+
+Every scan ends with a result summary: a severity table, the security score with a
+rating, a "Quick take" action block, the generated reports, and a suggested next
+command. Use `--quiet` for a compact result and `--no-color` for plain output. A failed
+scan exits non-zero, so it works cleanly in shells and CI.
 
 ---
 

--- a/docksec/cli.py
+++ b/docksec/cli.py
@@ -52,32 +52,43 @@ def main() -> None:
     parser.add_argument('--model', help='Model name to use (e.g., gpt-4o, claude-haiku-4-5, gemini-1.5-pro, llama3.1)')
     parser.add_argument('--compact-output', action='store_true', help='Use compact output format (less verbose)')
     parser.add_argument('--skip-ai-scoring', action='store_true', help='Skip AI-based security scoring (use local scoring only)')
+    parser.add_argument('--quiet', action='store_true', help='Reduce output to warnings, errors, and the result summary')
+    parser.add_argument('--no-color', action='store_true', help='Disable colored output (also honors the NO_COLOR env var)')
     parser.add_argument('--version', action='version', version=f'DockSec {get_version()}')
-    
+
     args = parser.parse_args()
-    
+
+    # Configure the terminal output layer before anything is printed.
+    from docksec import output
+    no_color = args.no_color or bool(os.getenv("NO_COLOR"))
+    if no_color:
+        # Every Rich console (including the AI-findings console in utils) honors
+        # NO_COLOR, so set it before those modules are imported.
+        os.environ["NO_COLOR"] = "1"
+    output.configure(quiet=args.quiet, no_color=no_color)
+
     # Set provider and model from CLI args if provided (overrides env vars)
     if args.provider:
         os.environ["LLM_PROVIDER"] = args.provider
     if args.model:
         os.environ["LLM_MODEL"] = args.model
-    
+
     # Set compact output mode if requested
     if args.compact_output:
         os.environ["DOCKSEC_COMPACT_OUTPUT"] = "true"
     
     # Validate argument combinations
     if args.image_only and args.ai_only:
-        print("Error: --image-only and --ai-only cannot be used together (AI analysis requires Dockerfile)")
+        output.error("--image-only and --ai-only cannot be used together (AI analysis requires a Dockerfile)")
         sys.exit(1)
     
     if args.image_only and args.scan_only:
-        print("Error: --image-only and --scan-only cannot be used together (use --image-only for image-only scanning)")
+        output.error("--image-only and --scan-only cannot be used together (use --image-only for image-only scanning)")
         sys.exit(1)
     
     # Validate Dockerfile requirement
     if not args.image_only and not args.compose and not args.dockerfile:
-        print("Error: Dockerfile path is required unless using --image-only or --compose")
+        output.error("Dockerfile path is required unless using --image-only or --compose")
         print("Usage examples:")
         print("  docksec Dockerfile -i myapp:latest          # Analyze both Dockerfile and image")
         print("  docksec --image-only -i myapp:latest        # Scan only the image")
@@ -87,18 +98,18 @@ def main() -> None:
     
     # Validate that the Dockerfile exists (if provided)
     if args.dockerfile and not os.path.isfile(args.dockerfile):
-        print(f"Error: Dockerfile not found at {args.dockerfile}")
+        output.error(f"Dockerfile not found at {args.dockerfile}")
         sys.exit(1)
     
     # Validate image requirement for image-based operations
     if args.image_only and not args.image:
-        print("Error: Image name is required for image-only scanning. Use -i/--image to specify the Docker image.")
+        output.error("Image name is required for image-only scanning. Use -i/--image to specify the Docker image.")
         print("Example: docksec --image-only -i myapp:latest")
         sys.exit(1)
     
     # In scan-only mode, if no image is provided, we'll only run Dockerfile analysis
     if args.scan_only and not args.image:
-        print("[INFO] No image provided for scan-only mode. Running Dockerfile analysis only.")
+        output.info("No image provided for scan-only mode. Running Dockerfile analysis only.")
     
     # Determine which tools to run
     if args.compose:
@@ -115,11 +126,11 @@ def main() -> None:
                     compose_path = name
                     break
             if compose_path == 'auto':
-                print("Error: Could not auto-detect a docker-compose file in the current directory.")
+                output.error("Could not auto-detect a docker-compose file in the current directory.")
                 sys.exit(1)
         
         if not os.path.isfile(compose_path):
-            print(f"Error: Compose file not found at {compose_path}")
+            output.error(f"Compose file not found at {compose_path}")
             sys.exit(1)
             
         args.compose = compose_path
@@ -145,21 +156,22 @@ def main() -> None:
         run_compose_analysis = False
         mode_desc = "Full Analysis (AI + Scanner)"
     
-    print(f"\n[INFO] Mode: {mode_desc}")
     from docksec.config import RESULTS_DIR
     from docksec.config_manager import get_config
     from docksec.enums import LLMProvider
-    print(f"[INFO] Reports will be saved to: {RESULTS_DIR}")
+
+    output.banner(get_version(), mode_desc)
+    output.kv("Reports", RESULTS_DIR)
     if run_ai:
         config = get_config()
-        print(f"[INFO] AI Provider: {config.llm_provider}")
+        output.kv("AI Provider", str(config.llm_provider))
     
     # Initialize AI findings storage
     ai_findings = None
     
     # Run the AI-based recommendation tool
     if run_ai:
-        print("\n=== Running AI-based Dockerfile analysis ===")
+        output.section("AI-based Dockerfile analysis")
         try:
             # Import required modules from main.py
             from docksec.utils import (
@@ -195,28 +207,29 @@ def main() -> None:
                 file_type = "Dockerfile"
             
             if not filecontent:
-                print(f"Error: No {file_type} content found.")
+                output.error(f"No {file_type} content found.")
                 return
-            
+
             # Truncate content to reduce token usage
             truncated_content = truncate_dockerfile(filecontent, max_lines=150, max_chars=4000) if run_compose_analysis else truncate_dockerfile(filecontent, max_lines=50, max_chars=2000)
-            
+
             response = analyser_chain.invoke({"filecontent": truncated_content})
             ai_findings = analyze_security(response, compact=True, report_path=RESULTS_DIR)
-            
+
         except ImportError as e:
-            print(f"Error: Required modules not found - {e}")
+            output.error(f"Required modules not found - {e}")
             sys.exit(1)
         except Exception as e:
-            print(f"Error running AI analysis: {e}")
+            output.error(f"AI analysis failed: {e}")
     
     # Run the scanner tool
+    scan_ok = None  # None = scan not run, True = success, False = failed
     if run_scan:
-        scan_type = "compose" if run_compose_analysis else ("image-only" if args.image_only else "full")
-        print(f"\n=== Running {scan_type} security scanner ===")
+        scan_title = "Compose" if run_compose_analysis else ("Image" if args.image_only else "Full")
+        output.section(f"{scan_title} security scan")
         try:
             from docksec.docker_scanner import DockerSecurityScanner
-            
+
             if run_compose_analysis:
                 from docksec.compose_scanner import ComposeOrchestrator
                 orchestrator = ComposeOrchestrator(
@@ -224,9 +237,9 @@ def main() -> None:
                     scan_only=not run_ai,
                     skip_ai_scoring=args.skip_ai_scoring
                 )
-                print(f"Scanning Compose file: {args.compose}")
+                output.info(f"Scanning Compose file: {args.compose}")
                 results = orchestrator.run_full_scan("CRITICAL,HIGH")
-                
+
                 # We need a scanner instance just for scoring and reporting
                 scanner = DockerSecurityScanner(None, None, scan_only=not run_ai, skip_ai_scoring=args.skip_ai_scoring)
                 scanner.image_name = "Multiple Services"
@@ -235,50 +248,130 @@ def main() -> None:
                 # Initialize the scanner
                 dockerfile_path = None if args.image_only else args.dockerfile
                 scanner = DockerSecurityScanner(
-                    dockerfile_path, 
-                    args.image, 
+                    dockerfile_path,
+                    args.image,
                     scan_only=not run_ai,
                     skip_ai_scoring=args.skip_ai_scoring
                 )
-                
+
                 # Run appropriate scan based on mode
                 if args.image_only:
                     # Image-only scan - skip Dockerfile analysis
-                    print(f"Scanning Docker image: {args.image}")
+                    output.info(f"Scanning Docker image: {args.image}")
                     results = scanner.run_image_only_scan("CRITICAL,HIGH")
                 else:
                     # Full scan including Dockerfile
                     results = scanner.run_full_scan("CRITICAL,HIGH")
-            
+
             # Calculate security score
             scanner.analysis_score = scanner.get_security_score(results)
-            
+
             # Add AI findings to results if available
             if ai_findings:
                 results["ai_findings"] = ai_findings
-            
+
             # Generate all reports
-            scanner.generate_all_reports(results)
-            
+            report_paths = scanner.generate_all_reports(results)
+
             # Run advanced scan if available and image is provided (skip for compose)
             if hasattr(scanner, 'advanced_scan') and args.image and not run_compose_analysis:
-                print("\n=== Running Advanced Scan ===")
+                output.section("Advanced scan (Docker Scout)")
                 scanner.advanced_scan()
-            
-            print("\n=== Scanning Complete ===")
-            
+
+            scan_ok = True
+            _render_scan_summary(output, args, scanner, results, report_paths,
+                                 run_ai, run_compose_analysis)
+
         except ValueError as e:
-            print(f"Scanner error: {e}")
+            # Expected, actionable failures (missing image, missing tools, bad input).
+            output.error(str(e))
+            scan_ok = False
         except ImportError as e:
-            print(f"Error: Scanner modules not found - {e}")
+            output.error(f"Scanner modules not found - {e}")
             sys.exit(1)
         except Exception as e:
-            print(f"Error running scanner: {e}")
-    
+            output.error(f"Scanner failed: {e}")
+            scan_ok = False
+
     if not run_ai and not run_scan:
-        print("No analysis performed. Use --help for usage information.")
-    else:
-        print("\nAnalysis complete!")
+        output.warn("No analysis performed. Use --help for usage information.")
+        sys.exit(2)
+
+    # Exit non-zero when the scan failed so CI and shells can react honestly.
+    if scan_ok is False:
+        sys.exit(1)
+
+
+def _render_scan_summary(output, args, scanner, results, report_paths,
+                         run_ai, run_compose_analysis):
+    """Render the consolidated result summary: severity table, score, a Quick
+    take action block, the generated reports, and a suggested next command."""
+    vulnerabilities = results.get("json_data", [])
+    counts = output.count_by_severity(vulnerabilities)
+
+    output.section("Results")
+    output.severity_table(counts)
+    output.score(getattr(scanner, "analysis_score", None))
+    output.quick_take(_quick_take_lines(results, counts, run_ai))
+    if report_paths:
+        output.report_results(report_paths, scanner.RESULTS_DIR)
+    output.next_command(_suggest_next_command(args, results, run_ai, run_compose_analysis))
+
+
+def _quick_take_lines(results, counts, run_ai):
+    """Build a few high-signal lines summarizing what matters most."""
+    lines = []
+
+    total_vulns = sum(counts.get(sev, 0) for sev in ("CRITICAL", "HIGH", "MEDIUM", "LOW"))
+    if total_vulns:
+        crit, high = counts.get("CRITICAL", 0), counts.get("HIGH", 0)
+        lines.append(f"{total_vulns} security findings ({crit} critical, {high} high)")
+
+    dockerfile_scan = results.get("dockerfile_scan", {})
+    if not dockerfile_scan.get("skipped") and not dockerfile_scan.get("success"):
+        output_text = dockerfile_scan.get("output") or ""
+        issue_lines = [ln for ln in output_text.splitlines() if ln.strip()]
+        if issue_lines:
+            top = _format_hadolint_line(issue_lines[0].strip())
+            lines.append(f"{len(issue_lines)} Dockerfile lint issues; top: {top}")
+
+    ai_findings = results.get("ai_findings") or {}
+    exposed = ai_findings.get("exposed_credentials") or []
+    if exposed:
+        lines.append(f"{len(exposed)} likely exposed credential(s) flagged by AI analysis")
+
+    if not run_ai and not results.get("ai_findings"):
+        lines.append("Run without --scan-only to add AI-powered explanations and fixes")
+
+    return lines
+
+
+def _format_hadolint_line(line):
+    """Turn a raw Hadolint line into a compact, path-free summary.
+
+    Input:  '/abs/path/Dockerfile:2 DL3020 error: Use COPY instead of ADD'
+    Output: 'DL3020 error: Use COPY instead of ADD (line 2)'
+    """
+    head, _, rest = line.partition(" ")
+    rest = rest.strip()
+    if not rest:
+        return line
+    line_no = head.rsplit(":", 1)[-1]
+    if line_no.isdigit():
+        return f"{rest} (line {line_no})"
+    return rest
+
+
+def _suggest_next_command(args, results, run_ai, run_compose_analysis):
+    """Suggest the most useful follow-up command for the current run."""
+    if run_compose_analysis:
+        return ""
+    dockerfile = getattr(args, "dockerfile", None)
+    # No image was scanned but a Dockerfile is present: suggest adding one.
+    image_skipped = results.get("image_scan", {}).get("skipped")
+    if dockerfile and image_skipped and not args.image:
+        return f"docksec {dockerfile} -i <your-image>:<tag>"
+    return ""
 
 if __name__ == "__main__":
     main()

--- a/docksec/docker_scanner.py
+++ b/docksec/docker_scanner.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import sys
 import re
 from pathlib import Path
+from docksec import output as ui  # aliased; a local var named `output` is used below
 from docksec.config import RESULTS_DIR, docker_score_prompt
 from docksec.enums import Severity
 from docksec.utils import ScoreResponse, get_llm, print_section, get_custom_logger
@@ -177,7 +178,7 @@ class DockerSecurityScanner:
             vulnerabilities: List of vulnerability dictionaries
         """
         if not vulnerabilities:
-            print("[SUCCESS] No vulnerabilities found.")
+            ui.success("No vulnerabilities found.")
             return
         
         severity_counts = defaultdict(int)
@@ -195,17 +196,17 @@ class DockerSecurityScanner:
             if count > 0:
                 summary_parts.append(f"{severity}: {count}")
         
-        print(f"  [VULNERABILITIES] {' | '.join(summary_parts)} | Total: {total}")
+        ui.detail(f"  Vulnerabilities: {' | '.join(summary_parts)} | Total: {total}")
         
         # Show top 3 critical/high only
         critical_high = [v for v in vulnerabilities if v.get('Severity') in [Severity.CRITICAL, Severity.HIGH]]
         if critical_high:
-            print("  Top Issues:")
+            ui.detail("  Top issues:")
             for i, vuln in enumerate(critical_high[:3], 1):
                 title = vuln.get('Title', 'N/A')
                 if title and len(title) > 60:
                     title = title[:57] + "..."
-                print(f"    • [{vuln.get('Severity')}] {vuln.get('VulnerabilityID', 'N/A')}: {title}")
+                ui.detail(f"    - [{vuln.get('Severity')}] {vuln.get('VulnerabilityID', 'N/A')}: {title}")
     
     def __init__(self, dockerfile_path: Optional[str], image_name: Optional[str], results_dir: str = RESULTS_DIR, scan_only: bool = False, skip_ai_scoring: bool = False):
         """
@@ -330,8 +331,8 @@ class DockerSecurityScanner:
         if self.use_cache:
             cached = self.cache.get(self.image_name)
             if cached:
-                print(f"[INFO] Using cached scan results for {self.image_name} (scanned at {cached.get('timestamp', 'N/A')})")
-                print("[TIP] To bypass cache, set environment variable DOCKSEC_USE_CACHE=false")
+                ui.info(f"Using cached scan results for {self.image_name} (scanned at {cached.get('timestamp', 'N/A')})")
+                ui.detail("Tip: set DOCKSEC_USE_CACHE=false to bypass the cache")
                 return cached.get('results', {})
         
         # Validate severity input
@@ -371,12 +372,12 @@ class DockerSecurityScanner:
 
         # Print final summary
         if not json_data:
-            print(f"[SUCCESS] Image scan completed for {self.image_name} (no vulnerabilities found).")
+            ui.success(f"Image scan completed for {self.image_name} (no vulnerabilities found).")
         else:
             severity_counts = defaultdict(int)
             for v in json_data:
                 severity_counts[v.get('Severity', Severity.UNKNOWN)] += 1
-            print(f"[INFO] Image scan completed for {self.image_name}. Found {len(json_data)} vulnerabilities.")
+            ui.info(f"Image scan completed for {self.image_name}. Found {len(json_data)} vulnerabilities.")
             # self._print_compact_vulnerability_summary(json_data) is already called in scan_image_json
 
         return results 
@@ -434,7 +435,6 @@ class DockerSecurityScanner:
                 - Optional[str]: Output from the scan or None if successful
         """
         logger.info(f"Starting Dockerfile scan with Hadolint: {self.dockerfile_path}")
-        print("\n=== Starting Dockerfile scan with Hadolint ===")
         try:
             result = subprocess.run(
                 ['hadolint', self.dockerfile_path],
@@ -447,14 +447,13 @@ class DockerSecurityScanner:
             if result.returncode != 0:
                 output = result.stdout if result.stdout else result.stderr
                 logger.warning(f"Hadolint found issues in {self.dockerfile_path}")
-                print("[WARNING] Dockerfile linting issues found:")
-                print(output)
-                print("\n[TIP] Run 'hadolint --help' to learn about specific rules")
-                print("   You can ignore specific rules with: hadolint --ignore DL3000 Dockerfile")
+                ui.warn("Dockerfile linting issues found:")
+                ui.detail(output)
+                ui.detail("Tip: ignore a rule with 'hadolint --ignore DL3000 <Dockerfile>'")
                 return False, output
             else:
                 logger.info("No Dockerfile linting issues found.")
-                print("[SUCCESS] No Dockerfile linting issues found.")
+                ui.success("No Dockerfile linting issues found.")
                 return True, None
                 
         except subprocess.CalledProcessError as e:
@@ -716,8 +715,8 @@ class DockerSecurityScanner:
         if self.image_name and self.use_cache:
             cached = self.cache.get(self.image_name)
             if cached:
-                print(f"[INFO] Using cached scan results for {self.image_name} (scanned at {cached.get('timestamp', 'N/A')})")
-                print("[TIP] To bypass cache, set environment variable DOCKSEC_USE_CACHE=false")
+                ui.info(f"Using cached scan results for {self.image_name} (scanned at {cached.get('timestamp', 'N/A')})")
+                ui.detail("Tip: set DOCKSEC_USE_CACHE=false to bypass the cache")
                 return cached.get('results', {})
         
         # Validate severity input
@@ -772,9 +771,9 @@ class DockerSecurityScanner:
         # Print final summary
         target_name = self.image_name if self.image_name else self.dockerfile_path
         if scan_status:
-            print(f"[SUCCESS] All security scans completed for {target_name}.")
+            ui.success(f"All security scans completed for {target_name}.")
         else:
-            print(f"[WARNING] Security scans completed for {target_name} with some issues.")
+            ui.warn(f"Security scans completed for {target_name} with some issues.")
 
         return results
 
@@ -813,19 +812,9 @@ class DockerSecurityScanner:
         from docksec.score_calculator import SecurityScoreCalculator
         calculator = SecurityScoreCalculator(skip_llm=True)
         breakdown = calculator.get_score_breakdown(results)
-        score = breakdown['overall']
-
-        print(f"Security Score: {score}/100")
-        if score >= 90:
-            print("[EXCELLENT] Excellent security posture!")
-        elif score >= 70:
-            print("[GOOD] Good security, but some improvements recommended")
-        elif score >= 50:
-            print("[FAIR] Fair security - multiple issues need attention")
-        else:
-            print("[POOR] Poor security - immediate action required")
-
-        return score
+        # The score and its rating are rendered once by the CLI summary
+        # (docksec.output.score); this method only computes the value.
+        return breakdown['overall']
 
     def get_security_score(self, results: Dict) -> float:
         """
@@ -854,11 +843,9 @@ class DockerSecurityScanner:
             
             # Send only summary, not full results dict
             score = self.score_chain.invoke({"results": vuln_summary})
-            print(f"Security Score: {score.score}")
             return score.score
         except Exception as e:
             logger.warning(f"AI scoring failed: {e}. Falling back to local scoring.")
-            print(f"AI scoring unavailable: {e}. Falling back to local scoring.")
             return self._calculate_local_score(results)
     
 def main():

--- a/docksec/output.py
+++ b/docksec/output.py
@@ -1,0 +1,235 @@
+"""
+Terminal output layer for DockSec.
+
+A single place that owns the look of everything DockSec prints to the terminal:
+the banner, section headers, status messages, the severity summary table, the
+security score line, the "Quick take" action block, the list of generated
+reports, and the suggested next command.
+
+Routing user-facing output through these helpers keeps the CLI visually
+consistent and makes global behavior (quiet mode, disabling color) a single
+switch instead of scattered ``print`` calls.
+
+Design notes:
+- Output goes to stdout via one shared Rich ``Console``. Logs go to stderr
+  (see ``utils.get_custom_logger``), so the two streams never fight.
+- No emoji or decorative glyphs are used; structure comes from color and
+  box-drawing table borders only.
+"""
+
+from typing import Dict, Iterable, List, Optional
+
+from rich.box import SQUARE
+from rich.console import Console
+from rich.table import Table
+from rich.text import Text
+
+# Module-level state configured once by the CLI.
+_state = {"quiet": False, "no_color": False}
+_console: Optional[Console] = None
+
+# Severity display order and colors used across the summary.
+_SEVERITY_STYLES = [
+    ("CRITICAL", "Critical", "bold red"),
+    ("HIGH", "High", "red"),
+    ("MEDIUM", "Medium", "yellow"),
+    ("LOW", "Low", "cyan"),
+]
+
+
+def configure(quiet: bool = False, no_color: bool = False) -> None:
+    """Configure the output layer. Called once, early, by the CLI."""
+    _state["quiet"] = quiet
+    _state["no_color"] = no_color
+    global _console
+    _console = Console(no_color=no_color, highlight=False)
+
+
+def get_console() -> Console:
+    """Return the shared console, creating a default one if needed."""
+    global _console
+    if _console is None:
+        _console = Console(no_color=_state["no_color"], highlight=False)
+    return _console
+
+
+def _line(renderable) -> None:
+    """Print a single line without hard-wrapping (long paths stay intact)."""
+    get_console().print(renderable, soft_wrap=True)
+
+
+def is_quiet() -> bool:
+    return bool(_state["quiet"])
+
+
+# ---------------------------------------------------------------------------
+# Basic building blocks
+# ---------------------------------------------------------------------------
+
+
+def banner(version: str, mode: str) -> None:
+    """Top-of-run banner with the tool version and the active mode."""
+    if is_quiet():
+        return
+    console = get_console()
+    console.print()
+    _line(
+        Text.assemble(
+            (f"DockSec {version}", "bold white"),
+            ("  -  ", "dim"),
+            ("Docker Security Scanner", "cyan"),
+        )
+    )
+    _line(Text(f"Mode: {mode}", style="dim"))
+
+
+def section(title: str) -> None:
+    """A section header, replacing the old ``=== title ===`` banners."""
+    if is_quiet():
+        return
+    get_console().print()
+    _line(Text(title, style="bold cyan"))
+
+
+def kv(label: str, value: str, label_width: int = 12) -> None:
+    """An aligned label/value line used for run metadata."""
+    if is_quiet():
+        return
+    _line(Text.assemble((f"{label:<{label_width}}", "bold"), (str(value), "default")))
+
+
+def info(message: str) -> None:
+    if is_quiet():
+        return
+    _line(Text.assemble(("info  ", "blue"), (message, "default")))
+
+
+def detail(message: str) -> None:
+    """Secondary/verbose detail (e.g. raw scanner output). Suppressed in quiet mode."""
+    if is_quiet():
+        return
+    _line(Text(message, style="default"))
+
+
+def success(message: str) -> None:
+    if is_quiet():
+        return
+    _line(Text.assemble(("ok    ", "green"), (message, "default")))
+
+
+def warn(message: str) -> None:
+    # Warnings survive quiet mode; they carry actionable signal.
+    _line(Text.assemble(("warn  ", "yellow"), (message, "default")))
+
+
+def error(message: str) -> None:
+    # Errors always print, even in quiet mode.
+    _line(Text.assemble(("error ", "bold red"), (message, "default")))
+
+
+# ---------------------------------------------------------------------------
+# Summary components
+# ---------------------------------------------------------------------------
+
+
+def severity_table(counts: Dict[str, int]) -> None:
+    """Render the box-drawing severity summary (Critical/High/Medium/Low)."""
+    console = get_console()
+    table = Table(box=SQUARE, show_edge=True, pad_edge=True, expand=False)
+    for _key, header, style in _SEVERITY_STYLES:
+        table.add_column(header, justify="center", style=style, header_style=style)
+    row = []
+    for key, _header, style in _SEVERITY_STYLES:
+        value = counts.get(key, 0)
+        row.append(Text(str(value), style=f"bold {style}" if value else "dim"))
+    table.add_row(*row)
+    if not is_quiet():
+        console.print()
+    console.print(table)
+
+
+def score(value, rating: Optional[str] = None) -> None:
+    """Render the security score with a color-coded rating band."""
+    console = get_console()
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        console.print(Text.assemble(("Security Score  ", "bold"), ("N/A", "dim")))
+        return
+
+    band, style = _score_band(numeric)
+    label = rating or band
+    if not is_quiet():
+        console.print()
+    _line(
+        Text.assemble(
+            ("Security Score  ", "bold"),
+            (f"{numeric:g} / 100", style),
+            ("   ", "default"),
+            (label, style),
+        )
+    )
+
+
+def _score_band(numeric: float):
+    if numeric >= 90:
+        return "EXCELLENT", "bold green"
+    if numeric >= 70:
+        return "GOOD", "green"
+    if numeric >= 50:
+        return "FAIR", "yellow"
+    return "POOR", "bold red"
+
+
+def quick_take(items: Iterable[str]) -> None:
+    """Render the 'Quick take' action block."""
+    items = [i for i in items if i]
+    if is_quiet() or not items:
+        return
+    console = get_console()
+    console.print()
+    _line(Text("Quick take", style="bold cyan"))
+    for item in items:
+        _line(Text.assemble(("  - ", "cyan"), (item, "default")))
+
+
+def report_results(paths: Dict[str, str], results_dir: str) -> None:
+    """List the report formats that were written and where."""
+    if is_quiet():
+        return
+    written = [fmt.upper() for fmt, path in paths.items() if path]
+    console = get_console()
+    console.print()
+    if written:
+        _line(
+            Text.assemble(
+                ("Reports  ", "bold"),
+                (", ".join(written), "green"),
+                ("  ->  ", "dim"),
+                (results_dir, "default"),
+            )
+        )
+    else:
+        _line(Text("Reports  none written", style="yellow"))
+
+
+def next_command(command: str) -> None:
+    """Suggest the next command the user might run."""
+    if is_quiet() or not command:
+        return
+    get_console().print()
+    _line(Text.assemble(("Next: ", "bold"), (command, "cyan")))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def count_by_severity(vulnerabilities: List[Dict]) -> Dict[str, int]:
+    """Count vulnerabilities by severity for the summary table."""
+    counts = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0, "UNKNOWN": 0}
+    for vuln in vulnerabilities or []:
+        severity = str(vuln.get("Severity", "UNKNOWN")).upper()
+        counts[severity] = counts.get(severity, 0) + 1
+    return counts

--- a/docksec/report_generator.py
+++ b/docksec/report_generator.py
@@ -19,6 +19,7 @@ import warnings
 from datetime import datetime
 from typing import Dict, List, Optional
 
+from docksec import output
 from docksec.config import RESULTS_DIR, get_html_template
 from docksec.utils import get_custom_logger
 
@@ -123,11 +124,10 @@ class ReportGenerator:
             with open(output_file, "w") as f:
                 json.dump(report_data, f, indent=4)
             logger.info("JSON report saved successfully")
-            print(f"[SUCCESS] JSON report saved to {output_file}")
             return output_file
         except Exception as e:
             logger.error(f"Error saving JSON report: {e}", exc_info=True)
-            print(f"[ERROR] Error saving JSON report: {e}")
+            output.error(f"Failed to save JSON report: {e}")
             return ""
 
     def generate_csv_report(self, results: Dict) -> str:
@@ -147,9 +147,6 @@ class ReportGenerator:
         if not vulnerabilities:
             logger.warning(
                 "No vulnerability data to save to CSV, creating header-only file"
-            )
-            print(
-                "[WARNING] No vulnerability data to save to CSV, creating header-only file"
             )
 
         try:
@@ -179,12 +176,11 @@ class ReportGenerator:
             logger.info(
                 f"CSV report saved successfully with {len(vulnerabilities)} vulnerabilities"
             )
-            print(f"[SUCCESS] CSV report saved to {output_file}")
             return output_file
 
         except Exception as e:
             logger.error(f"Error saving CSV report: {e}", exc_info=True)
-            print(f"[ERROR] Error saving CSV report: {e}")
+            output.error(f"Failed to save CSV report: {e}")
             return ""
 
     def generate_pdf_report(self, results: Dict) -> str:
@@ -481,12 +477,11 @@ class ReportGenerator:
 
             pdf.output(output_file)
             logger.info("PDF report saved successfully")
-            print(f"[SUCCESS] PDF report saved to {output_file}")
             return output_file
 
         except Exception as e:
             logger.error(f"Error saving PDF report: {e}", exc_info=True)
-            print(f"[ERROR] Error saving PDF report: {e}")
+            output.error(f"Failed to save PDF report: {e}")
             return ""
 
     def generate_html_report(self, results: Dict) -> str:
@@ -515,12 +510,11 @@ class ReportGenerator:
                 f.write(html_content)
 
             logger.info("HTML report saved successfully")
-            print(f"[SUCCESS] HTML report saved to {output_file}")
             return output_file
 
         except Exception as e:
             logger.error(f"Error saving HTML report: {e}", exc_info=True)
-            print(f"[ERROR] Error saving HTML report: {e}")
+            output.error(f"Failed to save HTML report: {e}")
             return ""
 
     def _prepare_html_template_vars(self, results: Dict) -> Dict[str, str]:
@@ -795,53 +789,24 @@ class ReportGenerator:
         """
         Generate all report formats.
 
+        Writing four files is effectively instant, so this runs silently and
+        returns the written paths; the CLI renders a single report summary from
+        the return value (see docksec.output.report_results).
+
         Args:
             results: Scan results dictionary
 
         Returns:
             Dictionary mapping format to file path
         """
-        from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn
-
         logger.info("Generating all report formats")
-        print("\n=== Generating Reports ===")
 
-        report_paths = {"json": "", "csv": "", "pdf": "", "html": ""}
+        report_paths = {
+            "json": self.generate_json_report(results),
+            "csv": self.generate_csv_report(results),
+            "pdf": self.generate_pdf_report(results),
+            "html": self.generate_html_report(results),
+        }
 
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
-            console=None,
-        ) as progress:
-            # JSON report
-            json_task = progress.add_task("[cyan]Generating JSON report...", total=1)
-            json_path = self.generate_json_report(results)
-            if json_path:
-                report_paths["json"] = json_path
-            progress.update(json_task, advance=1)
-
-            # CSV report
-            csv_task = progress.add_task("[cyan]Generating CSV report...", total=1)
-            csv_path = self.generate_csv_report(results)
-            if csv_path:
-                report_paths["csv"] = csv_path
-            progress.update(csv_task, advance=1)
-
-            # PDF report
-            pdf_task = progress.add_task("[cyan]Generating PDF report...", total=1)
-            pdf_path = self.generate_pdf_report(results)
-            if pdf_path:
-                report_paths["pdf"] = pdf_path
-            progress.update(pdf_task, advance=1)
-
-            # HTML report
-            html_task = progress.add_task("[cyan]Generating HTML report...", total=1)
-            html_path = self.generate_html_report(results)
-            if html_path:
-                report_paths["html"] = html_path
-            progress.update(html_task, advance=1)
-
-        print(f"\n[SUCCESS] Reports generated in: {self.results_dir}")
         logger.info(f"All reports generated: {report_paths}")
         return report_paths

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,13 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automatic scanning of all services defined in a docker-compose file.
 - Integration of compose findings into the existing LLM remediation and scoring pipeline.
 - `DOCKSEC_LOG_LEVEL` environment variable to override log verbosity (e.g. `DOCKSEC_LOG_LEVEL=DEBUG`) for troubleshooting.
+- **Redesigned terminal output**: a consolidated result summary with a box-drawing severity table, the security score with a color-coded rating, a "Quick take" action block highlighting the most important findings, the list of generated reports, and a suggested next command.
+- `--quiet` flag to reduce output to warnings, errors, and the result summary.
+- `--no-color` flag (also honors the `NO_COLOR` environment variable) to disable colored output.
 
 ### Changed
 - **Cleaner terminal output**: internal logs now write to `stderr` instead of `stdout` and stay quiet in CLI mode, so raw location-tagged log lines no longer interleave with the tool's user-facing messages. Set `DOCKSEC_LOG_LEVEL` to restore verbose logging.
+- The security score is now rendered once, in the result summary, instead of mid-scan.
+- Report generation runs silently and the CLI renders a single report summary from the result (removes the misleading progress bars).
+- **Honest exit codes**: a failed scan (for example, an image that is not found) now exits non-zero instead of ending with "Analysis complete!".
 
 ### Fixed
 - **PDF report encoding**: PDF generation no longer fails on non-latin-1 characters (bullets, smart quotes, em dashes, emoji) in vulnerability titles, scanner output, or AI findings; such characters are sanitized consistently across the whole document.
 - Suppressed the noisy `PyFPDF & fpdf2` import warning that printed on every run.
+- Fixed report progress output that printed each step twice and out of order (caused by mixing `print()` with a live progress display).
 
 ### Removed
 - Removed the unused `-o/--output` CLI flag, which was declared but never wired up.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -163,6 +163,83 @@ class TestCLI(unittest.TestCase):
                 # This tests that the env var would be set
                 pass
 
+    @patch('sys.argv', ['docksec', '/no/such/docksec_dockerfile_xyz', '--quiet', '--no-color'])
+    def test_quiet_and_no_color_flags_are_accepted(self):
+        """--quiet and --no-color must parse (argparse exits 2 on unknown flags)."""
+        from docksec.cli import main
+
+        with patch('builtins.print'):
+            with self.assertRaises(SystemExit) as ctx:
+                # The Dockerfile path does not exist, so main exits 1 during
+                # validation - well past argument parsing.
+                main()
+        self.assertNotEqual(ctx.exception.code, 2)
+
+
+class TestCLIHelpers(unittest.TestCase):
+    """Test cases for the CLI summary helper functions."""
+
+    def test_format_hadolint_line_strips_path_keeps_rule_and_line(self):
+        from docksec.cli import _format_hadolint_line
+
+        raw = "/abs/path/Dockerfile:2 DL3020 error: Use COPY instead of ADD"
+        self.assertEqual(
+            _format_hadolint_line(raw),
+            "DL3020 error: Use COPY instead of ADD (line 2)",
+        )
+
+    def test_format_hadolint_line_without_line_number(self):
+        from docksec.cli import _format_hadolint_line
+
+        self.assertEqual(_format_hadolint_line("just a message"), "a message")
+
+    def test_quick_take_reports_vulnerabilities_and_lint(self):
+        from docksec.cli import _quick_take_lines
+
+        results = {
+            "dockerfile_scan": {
+                "skipped": False,
+                "success": False,
+                "output": "/x/Dockerfile:2 DL3020 error: Use COPY instead of ADD",
+            },
+        }
+        counts = {"CRITICAL": 1, "HIGH": 2, "MEDIUM": 0, "LOW": 0}
+        lines = _quick_take_lines(results, counts, run_ai=True)
+        joined = " ".join(lines)
+        self.assertIn("3 security findings", joined)
+        self.assertIn("1 critical", joined)
+        self.assertIn("Dockerfile lint issues", joined)
+
+    def test_quick_take_suggests_ai_when_scan_only(self):
+        from docksec.cli import _quick_take_lines
+
+        results = {"dockerfile_scan": {"skipped": True}}
+        counts = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0}
+        lines = _quick_take_lines(results, counts, run_ai=False)
+        self.assertTrue(any("--scan-only" in line for line in lines))
+
+    def test_suggest_next_command_recommends_image_scan(self):
+        from docksec.cli import _suggest_next_command
+
+        class Args:
+            dockerfile = "Dockerfile"
+            image = None
+
+        results = {"image_scan": {"skipped": True}}
+        cmd = _suggest_next_command(Args(), results, run_ai=True, run_compose_analysis=False)
+        self.assertIn("Dockerfile", cmd)
+        self.assertIn("-i", cmd)
+
+    def test_suggest_next_command_empty_for_compose(self):
+        from docksec.cli import _suggest_next_command
+
+        class Args:
+            dockerfile = None
+            image = None
+
+        cmd = _suggest_next_command(Args(), {}, run_ai=True, run_compose_analysis=True)
+        self.assertEqual(cmd, "")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_docker_scanner.py
+++ b/tests/test_docker_scanner.py
@@ -170,42 +170,40 @@ class TestDockerSecurityScanner(unittest.TestCase):
         self.assertIn('unknown', unknown_instructions)
     
     @patch('docksec.docker_scanner.defaultdict')
-    @patch('builtins.print')
-    def test_print_compact_vulnerability_summary_no_vulns(self, mock_print, mock_defaultdict):
+    @patch('docksec.docker_scanner.ui')
+    def test_print_compact_vulnerability_summary_no_vulns(self, mock_ui, mock_defaultdict):
         """Test compact summary printing with no vulnerabilities."""
         from docksec.docker_scanner import DockerSecurityScanner
-        
+
         # Mock defaultdict to return a plain dict
         mock_defaultdict.side_effect = lambda: {}
-        
+
         scanner = DockerSecurityScanner.__new__(DockerSecurityScanner)
         scanner._print_compact_vulnerability_summary([])
-        
-        # Should print success message
-        mock_print.assert_called()
-    
-    @patch('builtins.print')
-    def test_print_compact_vulnerability_summary_with_vulns(self, mock_print):
+
+        # Should report the no-vulnerabilities success message via the output layer
+        mock_ui.success.assert_called()
+
+    @patch('docksec.docker_scanner.ui')
+    def test_print_compact_vulnerability_summary_with_vulns(self, mock_ui):
         """Test compact summary printing with vulnerabilities."""
         from docksec.docker_scanner import DockerSecurityScanner
-        
+
         vulnerabilities = [
             {'Severity': 'CRITICAL'},
             {'Severity': 'CRITICAL'},
             {'Severity': 'HIGH'},
             {'Severity': 'MEDIUM'},
         ]
-        
+
         scanner = DockerSecurityScanner.__new__(DockerSecurityScanner)
         scanner._print_compact_vulnerability_summary(vulnerabilities)
-        
-        # Should print summary
-        mock_print.assert_called()
-        # Check that all calls contain expected info
-        print_calls = [str(call) for call in mock_print.call_args_list]
-        combined_output = ' '.join(print_calls)
+
+        # Should render the summary via the output layer
+        mock_ui.detail.assert_called()
+        combined_output = ' '.join(str(call) for call in mock_ui.detail.call_args_list)
         self.assertIn('CRITICAL', combined_output)
-    
+
     def test_scan_results_cache_initialization(self):
         """Test ScanResultsCache initialization."""
         from docksec.docker_scanner import ScanResultsCache

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,86 @@
+"""Unit tests for the terminal output layer (docksec.output)."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from docksec import output
+
+
+def _capture(fn, *args, no_color=True, quiet=False):
+    """Run an output helper and return what it printed to the console."""
+    output.configure(quiet=quiet, no_color=no_color)
+    console = output.get_console()
+    with console.capture() as cap:
+        fn(*args)
+    return cap.get()
+
+
+def test_count_by_severity_counts_each_level():
+    vulns = [
+        {"Severity": "CRITICAL"},
+        {"Severity": "critical"},  # case-insensitive
+        {"Severity": "HIGH"},
+        {"Severity": "LOW"},
+        {},  # missing -> UNKNOWN
+    ]
+    counts = output.count_by_severity(vulns)
+    assert counts["CRITICAL"] == 2
+    assert counts["HIGH"] == 1
+    assert counts["LOW"] == 1
+    assert counts["MEDIUM"] == 0
+    assert counts["UNKNOWN"] == 1
+
+
+def test_count_by_severity_empty():
+    assert output.count_by_severity([])["CRITICAL"] == 0
+    assert output.count_by_severity(None)["HIGH"] == 0
+
+
+def test_severity_table_shows_headers_and_counts():
+    counts = {"CRITICAL": 3, "HIGH": 2, "MEDIUM": 0, "LOW": 1}
+    rendered = _capture(output.severity_table, counts)
+    for header in ("Critical", "High", "Medium", "Low"):
+        assert header in rendered
+    assert "3" in rendered and "2" in rendered and "1" in rendered
+
+
+def test_score_band_thresholds():
+    assert output._score_band(95)[0] == "EXCELLENT"
+    assert output._score_band(75)[0] == "GOOD"
+    assert output._score_band(55)[0] == "FAIR"
+    assert output._score_band(20)[0] == "POOR"
+
+
+def test_score_renders_band_label():
+    assert "GOOD" in _capture(output.score, 73.5)
+    assert "POOR" in _capture(output.score, 10)
+
+
+def test_score_handles_non_numeric():
+    assert "N/A" in _capture(output.score, None)
+
+
+def test_quiet_suppresses_info_but_not_error():
+    assert _capture(output.info, "hello", quiet=True) == ""
+    assert "boom" in _capture(output.error, "boom", quiet=True)
+
+
+def test_quiet_keeps_severity_table_and_score():
+    assert "Critical" in _capture(output.severity_table, {"CRITICAL": 1}, quiet=True)
+    assert "GOOD" in _capture(output.score, 80, quiet=True)
+
+
+def test_no_color_strips_ansi_escapes():
+    rendered = _capture(output.severity_table, {"CRITICAL": 1}, no_color=True)
+    assert "\x1b[" not in rendered
+
+
+def test_report_results_lists_written_formats():
+    rendered = _capture(
+        output.report_results, {"json": "a.json", "csv": "", "pdf": "c.pdf"}, "/tmp/out"
+    )
+    assert "JSON" in rendered and "PDF" in rendered
+    assert "CSV" not in rendered  # empty path is not listed
+    assert "/tmp/out" in rendered


### PR DESCRIPTION
## Summary

Reworks DockSec's terminal output into a clean, consistent result summary and fixes the
long-standing progress-bar and exit-code issues. Scanning logic is unchanged.

## Changes

### New output layer (`docksec/output.py`)
A single module owns the look of everything printed to the terminal: one shared Rich
console, section/status helpers, a box-drawing severity table, the score line, a
"Quick take" action block, the report list, and a suggested next command. No emoji;
structure comes from color and box-drawing borders only.

### Result summary
Every scan now ends with: a severity table (Critical/High/Medium/Low), the security
score with a color-coded rating, a Quick take highlighting the most important findings,
the generated reports, and a suggested next command.

### Fixed
- Report progress no longer prints each step twice / out of order (reports generate
  silently; the CLI renders one report line from the returned paths).
- A failed scan (e.g. image not found) now exits non-zero instead of ending with a
  misleading "Analysis complete!".

### Added
- `--quiet` - reduce output to warnings, errors, and the result summary.
- `--no-color` - disable colored output (also honors the `NO_COLOR` env var).

## Testing
- `ruff check .` passes.
- `pytest`: 102 passed (new `test_output.py`; updated scanner/CLI tests).
- Manual runs verified for scan-only, `--quiet`, `--no-color` (0 ANSI escapes), and
  `--compose`.

## Notes
- Scope is deliberately contained to CLI + summary/report output. A few verbose
  error-path troubleshooting prints in `docker_scanner` still use `print()`; routing
  those is a low-priority follow-up.
- Format selection and `--severity`/`--fail-on`/`--json`-to-stdout remain Phase 2.
