### PR TITLE
Phase 2e: add --sarif output and fix broken GitHub Action -o flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ docksec Dockerfile --scan-only --format json,html --output-dir ./reports
 # Print results as JSON to stdout for scripts and CI pipelines
 docksec -i myapp:latest --image-only --json
 
+# Write a SARIF report for GitHub Code Scanning
+docksec Dockerfile --scan-only --sarif
+
 # Reduce output to warnings, errors, and the result summary
 docksec Dockerfile --scan-only --quiet
 
@@ -139,6 +142,34 @@ docksec -i myapp:latest --image-only --json | jq '.severity_counts'
 With `--json` alone, no report files are written; combine it with `--format` to write
 files and print JSON in the same run. All human-readable messages (info, warnings,
 errors) move to stderr in `--json` mode, so stdout only ever contains the JSON payload.
+
+### SARIF output for GitHub Code Scanning
+
+`--sarif` writes a SARIF 2.1.0 report alongside the other report formats. Upload it
+with the standard `github/codeql-action/upload-sarif` action to see findings annotated
+directly on pull requests and in the Security tab:
+
+```yaml
+- name: Run DockSec
+  uses: OWASP/DockSec@main
+  with:
+    dockerfile: 'Dockerfile'
+    sarif: 'true'
+
+- name: Upload SARIF to GitHub Code Scanning
+  uses: github/codeql-action/upload-sarif@v3
+  if: always()
+  with:
+    sarif_file: ~/.docksec/results
+```
+
+> `if: always()` is important: without it, the upload step is skipped whenever
+> `--fail-on` causes DockSec to exit non-zero, losing the findings exactly when they
+> matter most.
+
+`--sarif` is independent of `--format`: it always writes a `.sarif` file regardless of
+which report formats you've selected, since it targets CI/Code Scanning rather than
+local reading.
 
 ### Exit codes
 

--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,24 @@ inputs:
     description: 'Path to docker-compose file to scan'
     required: false
   output:
-    description: 'Custom output file path'
+    description: 'Deprecated alias for output_dir. The standalone -o/--output file flag no longer exists; this value is now used as the report output directory.'
     required: false
+  output_dir:
+    description: 'Directory to write reports to (default: ~/.docksec/results in the container)'
+    required: false
+  severity:
+    description: 'Comma-separated severity levels for the image scan (default: CRITICAL,HIGH)'
+    required: false
+  fail_on:
+    description: 'Exit non-zero if any finding is at or above this severity (CRITICAL, HIGH, MEDIUM, or LOW)'
+    required: false
+  format:
+    description: 'Comma-separated report formats to write: json, csv, pdf, html (default: all)'
+    required: false
+  sarif:
+    description: 'Write a SARIF 2.1.0 report for GitHub Code Scanning'
+    required: false
+    default: 'false'
   openai_api_key:
     description: 'OpenAI API Key for AI analysis'
     required: false
@@ -56,6 +72,11 @@ runs:
     INPUT_IMAGE: ${{ inputs.image }}
     INPUT_COMPOSE: ${{ inputs.compose }}
     INPUT_OUTPUT: ${{ inputs.output }}
+    INPUT_OUTPUT_DIR: ${{ inputs.output_dir }}
+    INPUT_SEVERITY: ${{ inputs.severity }}
+    INPUT_FAIL_ON: ${{ inputs.fail_on }}
+    INPUT_FORMAT: ${{ inputs.format }}
+    INPUT_SARIF: ${{ inputs.sarif }}
     INPUT_OPENAI_API_KEY: ${{ inputs.openai_api_key }}
     INPUT_ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
     INPUT_GOOGLE_API_KEY: ${{ inputs.google_api_key }}

--- a/docksec/cli.py
+++ b/docksec/cli.py
@@ -57,6 +57,7 @@ def main() -> None:
     parser.add_argument('--format', dest='format', help='Comma-separated report formats to write: json, csv, pdf, html (default: all)')
     parser.add_argument('--output-dir', dest='output_dir', metavar='DIR', help='Directory to write reports to (default: ~/.docksec/results or DOCKSEC_RESULTS_DIR)')
     parser.add_argument('--json', dest='json_stdout', action='store_true', help='Print scan results as JSON to stdout (no report files unless --format is also given)')
+    parser.add_argument('--sarif', dest='sarif', action='store_true', help='Write a SARIF 2.1.0 report for GitHub Code Scanning and other SARIF-compatible tools')
     parser.add_argument('--quiet', action='store_true', help='Reduce output to warnings, errors, and the result summary')
     parser.add_argument('--no-color', action='store_true', help='Disable colored output (also honors the NO_COLOR env var)')
     parser.add_argument('--version', action='version', version=f'DockSec {get_version()}')
@@ -337,6 +338,11 @@ def main() -> None:
             # Generate reports (all formats by default, or the requested subset)
             report_paths = scanner.generate_all_reports(results, formats=report_formats)
 
+            # SARIF is opt-in via --sarif (not part of --format's default bundle)
+            # since it targets GitHub Code Scanning / CI rather than local reading.
+            if args.sarif:
+                report_paths["sarif"] = _generate_sarif_report(scanner, results)
+
             # Run advanced scan if available and image is provided (skip for compose
             # and for --json, since Docker Scout output is not part of the payload
             # and would otherwise print to stdout alongside it)
@@ -384,6 +390,21 @@ def main() -> None:
 
     if gate_triggered:
         sys.exit(1)
+
+
+def _generate_sarif_report(scanner, results):
+    """Write a SARIF 2.1.0 report for the scan and return its path.
+
+    Uses ReportGenerator directly (rather than DockerSecurityScanner's
+    generate_all_reports) because SARIF needs the DockSec version embedded in
+    the report and is opt-in via --sarif rather than part of --format's
+    default bundle.
+    """
+    from docksec.report_generator import ReportGenerator
+
+    generator = ReportGenerator(scanner.image_name or "docksec_report", scanner.RESULTS_DIR)
+    generator.set_analysis_score(getattr(scanner, "analysis_score", None))
+    return generator.generate_sarif_report(results, tool_version=get_version())
 
 
 def _print_json_results(results, scanner, report_paths):

--- a/docksec/report_generator.py
+++ b/docksec/report_generator.py
@@ -130,6 +130,144 @@ class ReportGenerator:
             output.error(f"Failed to save JSON report: {e}")
             return ""
 
+    def generate_sarif_report(self, results: Dict, tool_version: str = "unknown") -> str:
+        """
+        Generate a SARIF 2.1.0 report so findings can be uploaded to GitHub Code
+        Scanning (or any other SARIF-compatible consumer).
+
+        Each unique VulnerabilityID/rule-id becomes one SARIF rule, and each
+        finding becomes one SARIF result pointing at the scanned Dockerfile or
+        compose file. Findings with no source file to point at (e.g. an
+        image-only scan) still get a result, using the image name as a
+        synthetic artifact so they are not silently dropped.
+
+        Args:
+            results: Scan results dictionary
+            tool_version: DockSec version string to embed in the SARIF driver
+
+        Returns:
+            Path to the generated SARIF file, or empty string on failure
+        """
+        output_file = self._get_safe_filename("sarif")
+        logger.info(f"Generating SARIF report: {output_file}")
+
+        vulnerabilities = results.get("json_data", [])
+        artifact_uri = self._sarif_artifact_uri(results)
+
+        rules: Dict[str, Dict] = {}
+        sarif_results = []
+        for vuln in vulnerabilities:
+            rule_id = str(vuln.get("VulnerabilityID") or "UNKNOWN")
+            if rule_id not in rules:
+                rules[rule_id] = self._sarif_rule(rule_id, vuln)
+            sarif_results.append(self._sarif_result(rule_id, vuln, artifact_uri))
+
+        sarif_doc = {
+            "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+            "version": "2.1.0",
+            "runs": [
+                {
+                    "tool": {
+                        "driver": {
+                            "name": "DockSec",
+                            "informationUri": "https://owasp.org/DockSec/",
+                            "version": tool_version,
+                            "rules": list(rules.values()),
+                        }
+                    },
+                    "results": sarif_results,
+                }
+            ],
+        }
+
+        try:
+            with open(output_file, "w") as f:
+                json.dump(sarif_doc, f, indent=2)
+            logger.info(f"SARIF report saved successfully with {len(sarif_results)} results")
+            return output_file
+        except Exception as e:
+            logger.error(f"Error saving SARIF report: {e}", exc_info=True)
+            output.error(f"Failed to save SARIF report: {e}")
+            return ""
+
+    def _sarif_artifact_uri(self, results: Dict) -> str:
+        """Resolve the file SARIF results should point at.
+
+        Falls back to the image name when there is no Dockerfile/compose file
+        on disk (image-only scans), so results still have a valid location.
+        """
+        dockerfile_path = results.get("dockerfile_path")
+        if dockerfile_path and not str(dockerfile_path).startswith("N/A"):
+            return os.path.basename(str(dockerfile_path))
+        return self.image_name or "docksec-scan"
+
+    @staticmethod
+    def _sarif_level(severity) -> str:
+        """Map DockSec severities to SARIF result levels."""
+        mapping = {
+            "CRITICAL": "error",
+            "HIGH": "error",
+            "MEDIUM": "warning",
+            "LOW": "note",
+            "UNKNOWN": "note",
+        }
+        return mapping.get(str(severity or "UNKNOWN").upper(), "note")
+
+    @staticmethod
+    def _sarif_rule(rule_id: str, vuln: Dict) -> Dict:
+        """Build the SARIF rule (reportingDescriptor) for one finding type."""
+        rule = {
+            "id": rule_id,
+            "name": rule_id,
+            "shortDescription": {"text": vuln.get("Title") or rule_id},
+            "fullDescription": {"text": vuln.get("Description") or vuln.get("Title") or rule_id},
+            "defaultConfiguration": {"level": ReportGenerator._sarif_level(vuln.get("Severity"))},
+            "properties": {"security-severity": str(vuln.get("CVSS") or "")},
+        }
+        primary_url = vuln.get("PrimaryURL")
+        if primary_url:
+            rule["helpUri"] = primary_url
+        return rule
+
+    @staticmethod
+    def _sarif_result(rule_id: str, vuln: Dict, artifact_uri: str) -> Dict:
+        """Build one SARIF result for a finding."""
+        pkg = vuln.get("PkgName")
+        version = vuln.get("InstalledVersion")
+        message = vuln.get("Title") or rule_id
+        if pkg:
+            message = f"{message} ({pkg}{'@' + version if version else ''})"
+
+        region = ReportGenerator._sarif_region(vuln.get("Target"))
+        location = {
+            "physicalLocation": {
+                "artifactLocation": {"uri": artifact_uri},
+            }
+        }
+        if region:
+            location["physicalLocation"]["region"] = region
+
+        return {
+            "ruleId": rule_id,
+            "level": ReportGenerator._sarif_level(vuln.get("Severity")),
+            "message": {"text": message},
+            "locations": [location],
+        }
+
+    @staticmethod
+    def _sarif_region(target) -> Optional[Dict]:
+        """Extract a line-number region from a compose Target ('file:service:line').
+
+        Trivy image-vulnerability targets carry a package path, not a line
+        number, so this only produces a region for compose findings.
+        """
+        if not target:
+            return None
+        parts = str(target).rsplit(":", 1)
+        if len(parts) == 2 and parts[1].isdigit():
+            return {"startLine": max(1, int(parts[1]))}
+        return None
+
     def generate_csv_report(self, results: Dict) -> str:
         """
         Generate CSV format report for vulnerability data.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,12 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--format` flag to choose which report formats are written (`json`, `csv`, `pdf`, `html`; default: all). Invalid values are rejected with a clear error.
 - `--output-dir` flag to write reports to a specific directory for the run (default: `~/.docksec/results` or `DOCKSEC_RESULTS_DIR`).
 - `--json` flag: print scan results as a single JSON object to stdout for scripts and CI pipelines. All human-readable output (banner, sections, info/warn/error, the result summary) moves to stderr in `--json` mode, so stdout carries only the JSON payload. `--json` alone does not write report files; combine with `--format` to also write files.
+- `--sarif` flag: write a SARIF 2.1.0 report for GitHub Code Scanning and other SARIF-compatible tools. Independent of `--format`; findings map to one SARIF rule per unique vulnerability ID and one result per finding, with severity mapped to SARIF levels (`CRITICAL`/`HIGH` -> `error`, `MEDIUM` -> `warning`, `LOW`/`UNKNOWN` -> `note`).
+- GitHub Action inputs for the new CLI flags: `output_dir`, `severity`, `fail_on`, `format`, `sarif`.
 
 ### Changed
 - **Cleaner terminal output**: internal logs now write to `stderr` instead of `stdout` and stay quiet in CLI mode, so raw location-tagged log lines no longer interleave with the tool's user-facing messages. Set `DOCKSEC_LOG_LEVEL` to restore verbose logging.
 - The security score is now rendered once, in the result summary, instead of mid-scan.
 - Report generation runs silently and the CLI renders a single report summary from the result (removes the misleading progress bars).
 - **Honest exit codes**: a failed scan (for example, an image that is not found) now exits non-zero instead of ending with "Analysis complete!".
+
+### Fixed (GitHub Action)
+- The Action's `output` input was passed to the CLI as `-o`/`--output`, a flag removed earlier in this release; setting it caused every run to fail with an argument-parsing error. It is now remapped to `--output-dir` (kept as a deprecated alias; the new `output_dir` input is preferred).
 
 ### Fixed
 - **PDF report encoding**: PDF generation no longer fails on non-latin-1 characters (bullets, smart quotes, em dashes, emoji) in vulnerability titles, scanner output, or AI findings; such characters are sanitized consistently across the whole document.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,8 +26,29 @@ if [ -n "${INPUT_COMPOSE}" ]; then
   ARGS+=("-c" "${INPUT_COMPOSE}")
 fi
 
-if [ -n "${INPUT_OUTPUT}" ]; then
-  ARGS+=("-o" "${INPUT_OUTPUT}")
+# `output` is a deprecated alias for `output_dir` - the standalone -o/--output
+# file flag was removed from the CLI, so both inputs now map to --output-dir.
+# output_dir takes precedence if both are set.
+if [ -n "${INPUT_OUTPUT_DIR}" ]; then
+  ARGS+=("--output-dir" "${INPUT_OUTPUT_DIR}")
+elif [ -n "${INPUT_OUTPUT}" ]; then
+  ARGS+=("--output-dir" "${INPUT_OUTPUT}")
+fi
+
+if [ -n "${INPUT_SEVERITY}" ]; then
+  ARGS+=("--severity" "${INPUT_SEVERITY}")
+fi
+
+if [ -n "${INPUT_FAIL_ON}" ]; then
+  ARGS+=("--fail-on" "${INPUT_FAIL_ON}")
+fi
+
+if [ -n "${INPUT_FORMAT}" ]; then
+  ARGS+=("--format" "${INPUT_FORMAT}")
+fi
+
+if [ "${INPUT_SARIF}" = "true" ]; then
+  ARGS+=("--sarif")
 fi
 
 if [ "${INPUT_AI_ONLY}" = "true" ]; then

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -516,5 +516,61 @@ class TestJsonOutput(unittest.TestCase):
         self.assertEqual(len(printed), 1)
 
 
+class TestSarifOutput(unittest.TestCase):
+    """Test cases for --sarif wiring in the CLI."""
+
+    def _run_image_only(self, extra_argv=None):
+        """Run main() image-only with a mocked scanner and ReportGenerator."""
+        from docksec.cli import main
+
+        argv = ['docksec', '--image-only', '-i', 'test:latest'] + (extra_argv or [])
+        with patch('sys.argv', argv), \
+             patch('docksec.docker_scanner.DockerSecurityScanner') as scanner_cls, \
+             patch('docksec.report_generator.ReportGenerator') as report_cls:
+            scanner = Mock()
+            scanner_cls.return_value = scanner
+            scanner.image_name = "test:latest"
+            scanner.analysis_score = 90.0
+            scanner.RESULTS_DIR = '/tmp'
+            scanner.run_image_only_scan.return_value = {
+                'json_data': [],
+                'dockerfile_scan': {'skipped': True},
+                'image_scan': {'skipped': False},
+                'scan_mode': 'image_only',
+            }
+            scanner.get_security_score.return_value = 90.0
+            scanner.generate_all_reports.return_value = {'json': '/tmp/x.json'}
+
+            report_gen = Mock()
+            report_cls.return_value = report_gen
+            report_gen.generate_sarif_report.return_value = '/tmp/x.sarif'
+
+            code = 0
+            with patch('builtins.print'):
+                try:
+                    main()
+                except SystemExit as e:
+                    code = e.code
+            return code, report_gen, scanner_cls
+
+    def test_sarif_not_generated_without_flag(self):
+        _, report_gen, _ = self._run_image_only()
+        report_gen.generate_sarif_report.assert_not_called()
+
+    def test_sarif_flag_generates_report(self):
+        code, report_gen, _ = self._run_image_only(extra_argv=['--sarif'])
+        self.assertEqual(code, 0)
+        report_gen.generate_sarif_report.assert_called_once()
+        _, kwargs = report_gen.generate_sarif_report.call_args
+        self.assertIn('tool_version', kwargs)
+
+    def test_sarif_flag_does_not_affect_default_format_bundle(self):
+        """--sarif is additive; it must not change the --format-selected set."""
+        _, _, scanner_cls = self._run_image_only(extra_argv=['--sarif', '--format', 'json'])
+        scanner = scanner_cls.return_value
+        _, kwargs = scanner.generate_all_reports.call_args
+        self.assertEqual(kwargs.get('formats'), ['json'])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -288,3 +288,144 @@ def test_generate_all_reports_empty_formats_writes_nothing(tmp_path, sample_scan
     results = make_results([], sample_scan_info)
     paths = rg.generate_all_reports(results, formats=[])
     assert paths == {}
+
+
+# ---------- SARIF REPORT TESTS ----------
+
+
+def test_sarif_report_file_is_created(tmp_path, sample_vulnerabilities, sample_scan_info):
+    rg = ReportGenerator(image_name="test-image", results_dir=str(tmp_path))
+    results = make_results(sample_vulnerabilities, sample_scan_info)
+    output_path = rg.generate_sarif_report(results, tool_version="1.2.3")
+    assert os.path.exists(output_path)
+    assert output_path.endswith(".sarif")
+
+
+def test_sarif_report_has_valid_2_1_0_structure(
+    tmp_path, sample_vulnerabilities, sample_scan_info
+):
+    rg = ReportGenerator(image_name="test-image", results_dir=str(tmp_path))
+    results = make_results(sample_vulnerabilities, sample_scan_info)
+    output_path = rg.generate_sarif_report(results, tool_version="1.2.3")
+    with open(output_path) as f:
+        doc = json.load(f)
+
+    assert doc["version"] == "2.1.0"
+    assert "$schema" in doc
+    assert len(doc["runs"]) == 1
+    run = doc["runs"][0]
+    assert run["tool"]["driver"]["name"] == "DockSec"
+    assert run["tool"]["driver"]["version"] == "1.2.3"
+
+
+def test_sarif_report_maps_one_result_per_vulnerability(
+    tmp_path, sample_vulnerabilities, sample_scan_info
+):
+    rg = ReportGenerator(image_name="test-image", results_dir=str(tmp_path))
+    results = make_results(sample_vulnerabilities, sample_scan_info)
+    output_path = rg.generate_sarif_report(results, tool_version="1.2.3")
+    with open(output_path) as f:
+        doc = json.load(f)
+
+    run = doc["runs"][0]
+    assert len(run["results"]) == len(sample_vulnerabilities)
+    result = run["results"][0]
+    assert result["ruleId"] == sample_vulnerabilities[0]["VulnerabilityID"]
+    assert result["level"] == "error"  # CRITICAL -> error
+    assert sample_vulnerabilities[0]["PkgName"] in result["message"]["text"]
+    assert (
+        result["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+        == "Dockerfile"
+    )
+
+
+def test_sarif_report_dedupes_rules_by_vulnerability_id(tmp_path, sample_scan_info):
+    vulns = [
+        {
+            "VulnerabilityID": "CVE-2023-0001",
+            "Severity": "HIGH",
+            "PkgName": "openssl",
+            "InstalledVersion": "1.0.0",
+            "Title": "Issue A",
+            "Target": "img (pkg)",
+        },
+        {
+            "VulnerabilityID": "CVE-2023-0001",
+            "Severity": "HIGH",
+            "PkgName": "openssl",
+            "InstalledVersion": "1.0.1",
+            "Title": "Issue A",
+            "Target": "img (pkg)",
+        },
+    ]
+    rg = ReportGenerator(image_name="test-image", results_dir=str(tmp_path))
+    results = make_results(vulns, sample_scan_info)
+    output_path = rg.generate_sarif_report(results, tool_version="1.2.3")
+    with open(output_path) as f:
+        doc = json.load(f)
+
+    run = doc["runs"][0]
+    # Same VulnerabilityID -> one rule, but each finding still gets its own result.
+    assert len(run["tool"]["driver"]["rules"]) == 1
+    assert len(run["results"]) == 2
+
+
+def test_sarif_report_empty_vulnerabilities_no_crash(tmp_path, sample_scan_info):
+    rg = ReportGenerator(image_name="test-image", results_dir=str(tmp_path))
+    results = make_results([], sample_scan_info)
+    output_path = rg.generate_sarif_report(results, tool_version="1.2.3")
+    with open(output_path) as f:
+        doc = json.load(f)
+    assert doc["runs"][0]["results"] == []
+    assert doc["runs"][0]["tool"]["driver"]["rules"] == []
+
+
+def test_sarif_severity_level_mapping():
+    assert ReportGenerator._sarif_level("CRITICAL") == "error"
+    assert ReportGenerator._sarif_level("HIGH") == "error"
+    assert ReportGenerator._sarif_level("MEDIUM") == "warning"
+    assert ReportGenerator._sarif_level("LOW") == "note"
+    assert ReportGenerator._sarif_level("UNKNOWN") == "note"
+    assert ReportGenerator._sarif_level(None) == "note"
+    assert ReportGenerator._sarif_level("not-a-real-severity") == "note"
+
+
+def test_sarif_region_parses_compose_target_line_number():
+    region = ReportGenerator._sarif_region("docker-compose.yml:web:12")
+    assert region == {"startLine": 12}
+
+
+def test_sarif_region_none_for_non_numeric_target():
+    # Trivy image-vulnerability targets carry a package path, not a line number.
+    assert ReportGenerator._sarif_region("python:3.9-slim (debian 11)") is None
+    assert ReportGenerator._sarif_region(None) is None
+    assert ReportGenerator._sarif_region("") is None
+
+
+def test_sarif_artifact_uri_uses_dockerfile_basename(tmp_path, sample_scan_info):
+    rg = ReportGenerator(image_name="myapp:latest", results_dir=str(tmp_path))
+    results = {"dockerfile_path": "/some/deep/path/Dockerfile"}
+    assert rg._sarif_artifact_uri(results) == "Dockerfile"
+
+
+def test_sarif_artifact_uri_falls_back_to_image_name_for_image_only_scans(tmp_path):
+    rg = ReportGenerator(image_name="myapp:latest", results_dir=str(tmp_path))
+    results = {"dockerfile_path": "N/A - Image-only scan"}
+    assert rg._sarif_artifact_uri(results) == "myapp:latest"
+
+
+def test_sarif_rule_includes_help_uri_when_primary_url_present():
+    vuln = {
+        "VulnerabilityID": "CVE-2023-0001",
+        "Severity": "HIGH",
+        "Title": "Issue",
+        "PrimaryURL": "https://nvd.nist.gov/vuln/CVE-2023-0001",
+    }
+    rule = ReportGenerator._sarif_rule("CVE-2023-0001", vuln)
+    assert rule["helpUri"] == "https://nvd.nist.gov/vuln/CVE-2023-0001"
+
+
+def test_sarif_rule_omits_help_uri_when_no_primary_url():
+    vuln = {"VulnerabilityID": "compose-x", "Severity": "LOW", "Title": "Issue"}
+    rule = ReportGenerator._sarif_rule("compose-x", vuln)
+    assert "helpUri" not in rule


### PR DESCRIPTION
## Summary

Adds `--sarif` for GitHub Code Scanning integration — the last item in the Phase 2 CI
primitives sequence. While wiring it into the GitHub Action, found and fixed a real bug:
`entrypoint.sh` still passed the removed `-o/--output` flag, so any workflow setting the
Action's `output` input has been failing outright since the Phase 0 cleanup.

## Changes

### SARIF output
- `--sarif`: writes a SARIF 2.1.0 report, independent of `--format` (always written
  when the flag is set, regardless of which other formats are selected).
- One SARIF rule per unique vulnerability ID, one result per finding. Severity maps to
  SARIF levels (CRITICAL/HIGH -> error, MEDIUM -> warning, LOW/UNKNOWN -> note).
  PrimaryURL becomes the rule's helpUri when present.
- Result locations point at the scanned Dockerfile/compose file; image-only scans (no
  file on disk) fall back to the image name so results are never dropped. Compose
  findings get a line-number region parsed from their `file:service:line` Target.
- Appears in both the human report summary and --json's report_files.

### GitHub Action fix
- entrypoint.sh no longer passes -o (removed in Phase 0); output now maps to
  --output-dir. Added output_dir, severity, fail_on, format, and sarif as new Action
  inputs so the Phase 2 CLI surface is usable from the Action.
- output is kept as a deprecated alias for output_dir so existing workflows keep working.

## Testing
- `ruff check .` passes.
- `pytest`: 141 passed (+15: SARIF structure/dedup/region/severity-mapping/fallback
  tests, plus CLI-level --sarif wiring tests).
- Manual runs verified: valid SARIF 2.1.0 output, combos with --json/--format/--fail-on,
  image-only artifact fallback, and entrypoint.sh syntax.

## Notes
This closes out Phase 2 (CI primitives): --severity, --fail-on + exit codes,
--format/--output-dir, --json, --sarif.
