### PR TITLE
Bump version to 2026.7.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="docksec",
-    version="2026.6.24",
+    version="2026.7.1",
     description="AI-Powered Docker Security Analyzer",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Summary

Bumps setup.py to 2026.7.1 ahead of the release workflow run. The release workflow
commits its version bump directly to main, which now fails branch protection (PR-only,
required status checks) - pre-bumping via a normal PR avoids that direct-push conflict.

## Testing
- No behavior change; version string only.
