### PR TITLE
Add contributor-focused GitHub workflows

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,57 @@
+cli:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docksec/cli.py
+
+core:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docksec/docker_scanner.py
+          - docksec/compose_scanner.py
+          - docksec/score_calculator.py
+          - docksec/baseline.py
+          - docksec/utils.py
+          - docksec/enums.py
+
+reports:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docksec/report_generator.py
+          - docksec/templates/**
+
+config:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docksec/config.py
+          - docksec/config_manager.py
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/workflows/**
+
+docker:
+  - changed-files:
+      - any-glob-to-any-file:
+          - Dockerfile
+          - action.yml
+          - entrypoint.sh
+          - examples/compose/**
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.md'
+          - docs/**
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - requirements.txt
+          - setup.py
+          - pyproject.toml
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - tests/**

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,30 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.5.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    timeout-minutes: 5

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,22 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  dependency-review:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          comment-summary-in-pr: always
+    timeout-minutes: 5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,29 @@
+name: Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.13'
+
+      - name: Install lint tools
+        run: pip install ruff
+
+      - name: Run ruff
+        run: ruff check .
+    timeout-minutes: 5

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,19 @@
+name: Label Pull Requests
+
+on:
+  - pull_request_target
+
+permissions: {}
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
+        with:
+          configuration-path: .github/pr-labeler.yml
+          sync-labels: true
+    timeout-minutes: 5

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,39 @@
+name: Close Stale Issues and PRs
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  stale:
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v10.1.0
+        with:
+          days-before-stale: 60
+          days-before-close: 14
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: pinned,security,good first issue
+          exempt-pr-labels: pinned,security
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs. Thank you
+            for your contributions.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not
+            had recent activity. It will be closed if no further activity occurs. Thank
+            you for your contributions.
+          close-issue-message: >
+            This issue was closed because it has been stalled for 14 days with no
+            activity.
+          close-pr-message: >
+            This pull request was closed because it has been stalled for 14 days with
+            no activity.
+    timeout-minutes: 10

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,0 +1,31 @@
+name: Welcome First-Time Contributors
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request_target:
+    types:
+      - opened
+
+permissions: {}
+
+jobs:
+  welcome:
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/first-interaction@1d02526d949a90f18ba22cd8c1e7cddd97ba6ee8 # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: >
+            Thanks for opening your first issue in DockSec! A maintainer will take a
+            look soon. In the meantime, please make sure you've included enough detail
+            to reproduce the problem — see CONTRIBUTING.md for guidelines.
+          pr-message: >
+            Thanks for your first pull request to DockSec! Please make sure the test
+            suite passes and take a look at CONTRIBUTING.md if you haven't already.
+            A maintainer will review this shortly.
+    timeout-minutes: 5


### PR DESCRIPTION
## Summary
- Add PR auto-labeler (`pr-labeler.yml` + `.github/pr-labeler.yml`) to tag PRs by
  changed path (cli, core, reports, config, ci, docker, documentation, dependencies, tests)
- Add stale bot to close inactive issues/PRs after 60/14 days, exempting
  pinned/security/good-first-issue
- Add first-interaction welcome message for new issue/PR authors
- Add standalone ruff lint job for fast style feedback on PRs
- Add dependency review to flag vulnerable/incompatible deps on PRs
- Add Dependabot auto-merge for patch/minor version bumps once checks pass

## Notes
- New labels created in the repo: cli, core, reports, config, ci, docker, tests, stale
- Lint workflow only runs ruff (already clean); black/isort were left out since the
  existing codebase isn't formatted to those standards yet and would fail as a new
  required check
