### PR TITLE
docs: document report formats and CSV header behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,19 @@ With `--json` alone, no report files are written; combine it with `--format` to 
 files and print JSON in the same run. All human-readable messages (info, warnings,
 errors) move to stderr in `--json` mode, so stdout only ever contains the JSON payload.
 
+### Report Formats
+
+When using the `--format` flag, you can export your security scan results into four different formats. Each format serves a specific use case:
+
+*   **json**: Full, machine-readable scan data containing core metrics and any AI-generated findings. For stdout piping options, see the [Machine-readable output](#machine-readable-output) section above.
+*   **html**: An interactive, visually clean web report summarizing your findings.
+*   **pdf**: A portable, presentation-ready document summing up the report.
+*   **csv**: A spreadsheet-ready tabular format listing out individual vulnerabilities.
+
+> ⚠️ **Note on CSV Behavior:** If DockSec detects **zero vulnerabilities**, it will still generate a CSV file, but it will be **header-only** (containing only the column names with no data rows). This is intentional behavior to prevent downstream automated tools or CI/CD pipelines from breaking on a completely empty file, and should not be treated as a bug.
+
+For specialized cloud-native workflows, you can also cross-reference the [SARIF output](#sarif-output) section.
+
 ### SARIF output for GitHub Code Scanning
 
 `--sarif` writes a SARIF 2.1.0 report alongside the other report formats. Upload it


### PR DESCRIPTION
## Description

Added a dedicated "Report Formats" subsection to the README under the Quick Start area to clarify the available export configurations and document unique output behaviors.

Closes #132

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code style update (formatting, renaming)
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update
- [ ] Build / CI configuration
- [ ] Security fix

## How Has This Been Tested?

Verified by previewing the Markdown rendering locally to ensure headers, bullet points, code references, and anchor links resolve correctly.

- [ ] Unit tests
- [x] Manual testing

**Test Configuration:**
- Python version: 3.x
- Operating System: Windows (PowerShell)
- DockSec version: Local dev branch

## Checklist

- [x] Code follows the style guidelines of this project
- [x] Self-review completed
- [x] Hard-to-understand areas are commented
- [x] Documentation updated where needed
- [x] No new warnings or errors introduced
- [ ] Tests added that prove the fix or feature works
- [x] All existing tests pass
- [ ] Dependent changes have been merged and published
- [x] Spelling checked

## Screenshots (if applicable)

## Related Issues / PRs

- Relates to #132
- Depends on #

---

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.