### PR TITLE
Add SBOM export, offline mode, install-skill, and fix-command output

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,15 @@ docksec -i myapp:latest --image-only --json
 # Write a SARIF report for GitHub Code Scanning
 docksec Dockerfile --scan-only --sarif
 
+# Write a CycloneDX SBOM of an image for supply-chain tooling
+docksec --image-only -i myapp:latest --sbom
+
+# Fully offline scan: local Trivy DB, no network, no AI
+docksec --image-only -i myapp:latest --offline
+
+# Install AI-assistant skill files (Claude Code, Cursor, Copilot, and more)
+docksec install-skill
+
 # Save today's findings as a baseline, then only gate on new findings later
 docksec -i myapp:latest --image-only --baseline .docksec-baseline.json --update-baseline
 docksec -i myapp:latest --image-only --baseline .docksec-baseline.json --fail-on high
@@ -175,6 +184,55 @@ directly on pull requests and in the Security tab:
 which report formats you've selected, since it targets CI/Code Scanning rather than
 local reading.
 
+### CycloneDX SBOM
+
+`--sbom` writes a CycloneDX software bill of materials (`<image>.cdx.json`) of the
+scanned image, listing every package component plus known vulnerabilities. The BOM is
+produced by Trivy's native exporter (so it is spec-compliant) and DockSec stamps itself
+into the tool metadata. Feed it into Dependency-Track, GitHub's dependency graph, or any
+other SBOM consumer:
+
+```bash
+docksec --image-only -i myapp:latest --sbom
+```
+
+`--sbom` needs a single image (`-i`), so it is skipped for compose runs. Like `--sarif`,
+it is independent of `--format`.
+
+### Offline mode
+
+`--offline` runs a scan with no network access. It uses the Trivy vulnerability database
+already on disk (no DB update) and skips the AI analysis and the Docker Scout advanced
+scan, both of which require network. This is the simplest way to scan in an air-gapped or
+locked-down environment:
+
+```bash
+docksec --image-only -i myapp:latest --offline
+```
+
+Make sure the Trivy DB has been downloaded at least once (any prior online scan does
+this) before relying on `--offline`.
+
+### AI-assistant skills (`install-skill`)
+
+`docksec install-skill` writes DockSec usage instructions into the well-known context
+files for popular AI coding assistants, so an assistant working in your repo knows how to
+invoke DockSec:
+
+```bash
+docksec install-skill
+```
+
+This creates or updates:
+
+- `.claude/commands/docksec.md` (Claude Code slash command `/docksec`)
+- `.cursor/rules/docksec.mdc` (Cursor)
+- `AGENTS.md` (Codex CLI), `GEMINI.md` (Gemini CLI)
+- `.github/copilot-instructions.md` (GitHub Copilot)
+
+The files are plain text you can review and commit; nothing is executed. Re-running the
+command updates the DockSec section in place instead of duplicating it.
+
 ### Baseline / ratchet mode
 
 `--baseline FILE` lets you adopt `--fail-on` on an existing project without a wall of
@@ -220,8 +278,11 @@ severity is widened automatically so the gate can observe those findings.
 - **Deep Integration**: Combines Trivy (vulnerabilities), Hadolint (linting), and Docker Scout.
 - **Security Scoring**: Get a 0-100 score to track your security posture over time.
 - **Centralized Reporting**: All reports are neatly organized in `~/.docksec/results/` by default.
-- **Rich Formats**: Professional exports in HTML (interactive), PDF, JSON, and CSV.
+- **Rich Formats**: Professional exports in HTML (interactive), PDF, JSON, CSV, SARIF, and CycloneDX SBOM.
+- **Supply-Chain Ready**: Generate a CycloneDX SBOM (`--sbom`) of any image for Dependency-Track and other consumers.
+- **Offline Mode**: Scan fully air-gapped (`--offline`) using the local Trivy database, no network required.
 - **CI/CD Ready**: Designed for easy integration into GitHub Actions and build pipelines.
+- **AI-Assistant Skills**: `docksec install-skill` teaches Claude Code, Cursor, Copilot, and others how to run DockSec in your repo.
 - **GitHub Action**: Available on the GitHub Marketplace for automated security scans.
 
 ---
@@ -242,7 +303,8 @@ Legend: ✅ full support &nbsp; ⚠️ partial or caveated &nbsp; ❌ not suppor
 | Docker Compose (multi service) scanning | ✅ Yes (orchestration checks and per service scan) | ⚠️ Partial (config scan, no per service fan out) | ⚠️ Partial | ⚠️ Partial |
 | Baseline / ratchet mode (fail only on new findings) | ✅ Yes | ❌ No | ⚠️ Partial (platform policies) | ⚠️ Partial (platform policies) |
 | CI native output (SARIF for GitHub Code Scanning) | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
-| SBOM export (CycloneDX / SPDX) | ❌ No (on the roadmap) | ✅ Yes | ✅ Yes | ✅ Yes |
+| SBOM export (CycloneDX) | ✅ Yes (`--sbom`) | ✅ Yes | ✅ Yes | ✅ Yes |
+| AI-assistant skill install (Claude Code, Cursor, Copilot) | ✅ Yes (`install-skill`) | ❌ No | ❌ No | ❌ No |
 | Runs fully offline / air gapped | ✅ Yes (local LLM via Ollama, scan only mode, no API key) | ⚠️ Yes for scanning (no remediation layer) | ❌ No (cloud platform) | ❌ No (hosted platform) |
 | Your image data stays on your network | ✅ Yes | ✅ Yes | ❌ No | ❌ No |
 | Bring your own LLM / model choice | ✅ Yes (OpenAI, Anthropic, Gemini, or local Ollama) | ⚠️ Not applicable | ❌ No (proprietary AI) | ❌ No (proprietary AI) |

--- a/docksec/cli.py
+++ b/docksec/cli.py
@@ -38,7 +38,18 @@ def main() -> None:
     """
     # Set CLI mode to suppress INFO logs for user-facing output
     os.environ["DOCKSEC_CLI_MODE"] = "true"
-    
+
+    # Subcommand dispatch (backward compatible): the historical CLI takes a
+    # positional Dockerfile, so we intercept known verbs as the first argument
+    # before argparse runs. Anything else falls through to the existing
+    # flag-based scan CLI unchanged.
+    if len(sys.argv) > 1 and sys.argv[1] == "install-skill":
+        from docksec import output
+        output.configure()
+        from docksec.install_skill import install_skill
+        install_skill()
+        return
+
     from docksec.enums import LLMProvider
     parser = argparse.ArgumentParser(description='Docker Security Analysis Tool')
     parser.add_argument('dockerfile', nargs='?', help='Path to the Dockerfile to analyze (optional when using --image-only or --compose)')
@@ -58,6 +69,8 @@ def main() -> None:
     parser.add_argument('--output-dir', dest='output_dir', metavar='DIR', help='Directory to write reports to (default: ~/.docksec/results or DOCKSEC_RESULTS_DIR)')
     parser.add_argument('--json', dest='json_stdout', action='store_true', help='Print scan results as JSON to stdout (no report files unless --format is also given)')
     parser.add_argument('--sarif', dest='sarif', action='store_true', help='Write a SARIF 2.1.0 report for GitHub Code Scanning and other SARIF-compatible tools')
+    parser.add_argument('--sbom', dest='sbom', action='store_true', help='Write a CycloneDX SBOM (.cdx.json) of the scanned image for supply-chain tooling (requires an image)')
+    parser.add_argument('--offline', dest='offline', action='store_true', help='Run without network access: use the local Trivy DB (no DB update) and skip AI analysis')
     parser.add_argument('--baseline', dest='baseline', metavar='FILE', help='Path to a baseline file; with --fail-on, only findings not present in the baseline trigger the gate')
     parser.add_argument('--update-baseline', dest='update_baseline', action='store_true', help='Write the current scan findings to --baseline instead of gating against it')
     parser.add_argument('--quiet', action='store_true', help='Reduce output to warnings, errors, and the result summary')
@@ -162,6 +175,7 @@ def main() -> None:
         print("  docksec --image-only -i myapp:latest        # Scan only the image")
         print("  docksec --compose docker-compose.yml        # Scan compose file and its services")
         print("  docksec --ai-only Dockerfile                # AI analysis only")
+        print("  docksec install-skill                       # Install AI-assistant skill files")
         sys.exit(2)
     
     # Validate that the Dockerfile exists (if provided)
@@ -224,6 +238,14 @@ def main() -> None:
         run_compose_analysis = False
         mode_desc = "Full Analysis (AI + Scanner)"
     
+    # Offline mode: no network calls. AI providers all require network (except
+    # a local Ollama, but we keep this simple and predictable), so --offline
+    # forces local scanning + local scoring only. The scan still runs against
+    # the already-downloaded Trivy DB.
+    if args.offline:
+        run_ai = False
+        mode_desc = f"{mode_desc} (offline)"
+
     from docksec.config_manager import get_config
     from docksec.enums import LLMProvider
 
@@ -314,7 +336,7 @@ def main() -> None:
                 results = orchestrator.run_full_scan(severity)
 
                 # We need a scanner instance just for scoring and reporting
-                scanner = DockerSecurityScanner(None, None, results_dir=output_dir, scan_only=not run_ai, skip_ai_scoring=args.skip_ai_scoring)
+                scanner = DockerSecurityScanner(None, None, results_dir=output_dir, scan_only=not run_ai, skip_ai_scoring=args.skip_ai_scoring, offline=args.offline)
                 scanner.image_name = "Multiple Services"
                 scanner.dockerfile_path = args.compose
             else:
@@ -325,7 +347,8 @@ def main() -> None:
                     args.image,
                     results_dir=output_dir,
                     scan_only=not run_ai,
-                    skip_ai_scoring=args.skip_ai_scoring
+                    skip_ai_scoring=args.skip_ai_scoring,
+                    offline=args.offline
                 )
 
                 # Run appropriate scan based on mode
@@ -352,11 +375,23 @@ def main() -> None:
             if args.sarif:
                 report_paths["sarif"] = _generate_sarif_report(scanner, results)
 
+            # SBOM is opt-in via --sbom. It needs a real image to inventory, so
+            # it is skipped (with a note) for compose runs and when no image was
+            # scanned.
+            if args.sbom:
+                if run_compose_analysis or not args.image:
+                    output.warn("--sbom needs a single image (-i); skipping SBOM for this run.")
+                else:
+                    sbom_path = _generate_sbom_report(scanner)
+                    if sbom_path:
+                        report_paths["sbom"] = sbom_path
+
             # Run advanced scan if available and image is provided (skip for compose
             # and for --json, since Docker Scout output is not part of the payload
-            # and would otherwise print to stdout alongside it)
+            # and would otherwise print to stdout alongside it; skip in --offline
+            # since Docker Scout reaches out to Docker's servers)
             if hasattr(scanner, 'advanced_scan') and args.image and not run_compose_analysis \
-                    and not args.json_stdout:
+                    and not args.json_stdout and not args.offline:
                 output.section("Advanced scan (Docker Scout)")
                 scanner.advanced_scan()
 
@@ -472,6 +507,22 @@ def _generate_sarif_report(scanner, results):
     return generator.generate_sarif_report(results, tool_version=get_version())
 
 
+def _generate_sbom_report(scanner):
+    """Generate a CycloneDX SBOM for the scanned image and return its path.
+
+    The BOM is produced by Trivy via the scanner (full package inventory) and
+    written by ReportGenerator with DockSec stamped into the tool metadata.
+    Returns an empty string if the image could not be inventoried.
+    """
+    from docksec.report_generator import ReportGenerator
+
+    sbom_json = scanner.generate_sbom()
+    if not sbom_json:
+        return ""
+    generator = ReportGenerator(scanner.image_name or "docksec_report", scanner.RESULTS_DIR)
+    return generator.generate_cyclonedx_report(sbom_json, tool_version=get_version())
+
+
 def _print_json_results(results, scanner, report_paths):
     """Print scan results as a single JSON object to stdout.
 
@@ -515,6 +566,7 @@ def _render_scan_summary(output, args, scanner, results, report_paths,
     output.severity_table(counts)
     output.score(getattr(scanner, "analysis_score", None))
     output.quick_take(_quick_take_lines(results, counts, run_ai))
+    output.fix_commands(_suggest_fix_commands(results))
     if report_paths:
         output.report_results(report_paths, scanner.RESULTS_DIR)
     output.next_command(_suggest_next_command(args, results, run_ai, run_compose_analysis))
@@ -524,10 +576,17 @@ def _quick_take_lines(results, counts, run_ai):
     """Build a few high-signal lines summarizing what matters most."""
     lines = []
 
+    vulnerabilities = results.get("json_data", [])
     total_vulns = sum(counts.get(sev, 0) for sev in ("CRITICAL", "HIGH", "MEDIUM", "LOW"))
     if total_vulns:
         crit, high = counts.get("CRITICAL", 0), counts.get("HIGH", 0)
         lines.append(f"{total_vulns} security findings ({crit} critical, {high} high)")
+
+        # How many findings have a known fixed version available upstream — a
+        # high-signal, actionable number (mirrors cve-lite's fixable count).
+        fixable = sum(1 for v in vulnerabilities if v.get("FixedVersion"))
+        if fixable:
+            lines.append(f"{fixable} of {total_vulns} have a fixed version available upstream")
 
     dockerfile_scan = results.get("dockerfile_scan", {})
     if not dockerfile_scan.get("skipped") and not dockerfile_scan.get("success"):
@@ -578,6 +637,34 @@ def _format_hadolint_line(line):
     if line_no.isdigit():
         return f"{rest} (line {line_no})"
     return rest
+
+
+def _suggest_fix_commands(results, limit=5):
+    """Build copy-pasteable upgrade hints from findings that have a fixed version.
+
+    Trivy reports the first fixed version per vulnerable package; we surface the
+    most severe fixable packages as concrete 'upgrade PKG to VERSION' lines so a
+    user has an immediate next action, not just a CVE list. Deduplicated by
+    package name (a package can carry several CVEs), most severe first.
+    """
+    from docksec.enums import Severity
+
+    fixable = [v for v in results.get("json_data", []) if v.get("FixedVersion") and v.get("PkgName")]
+    fixable.sort(key=lambda v: Severity.rank(v.get("Severity")), reverse=True)
+
+    seen = set()
+    commands = []
+    for v in fixable:
+        pkg = v.get("PkgName")
+        if pkg in seen:
+            continue
+        seen.add(pkg)
+        installed = v.get("InstalledVersion") or "current"
+        fixed = v.get("FixedVersion")
+        commands.append(f"upgrade {pkg} {installed} -> {fixed}")
+        if len(commands) >= limit:
+            break
+    return commands
 
 
 def _suggest_next_command(args, results, run_ai, run_compose_analysis):

--- a/docksec/docker_scanner.py
+++ b/docksec/docker_scanner.py
@@ -210,7 +210,7 @@ class DockerSecurityScanner:
                     title = title[:57] + "..."
                 ui.detail(f"    - [{vuln.get('Severity')}] {vuln.get('VulnerabilityID', 'N/A')}: {title}")
     
-    def __init__(self, dockerfile_path: Optional[str], image_name: Optional[str], results_dir: str = RESULTS_DIR, scan_only: bool = False, skip_ai_scoring: bool = False):
+    def __init__(self, dockerfile_path: Optional[str], image_name: Optional[str], results_dir: str = RESULTS_DIR, scan_only: bool = False, skip_ai_scoring: bool = False, offline: bool = False):
         """
         Initialize the Docker Security Scanner with a Dockerfile path and/or image name.
         Verifies that required tools are installed and the specified files exist.
@@ -242,6 +242,10 @@ class DockerSecurityScanner:
         self.RESULTS_DIR = results_dir
         self.scan_only = scan_only
         self.skip_ai_scoring = skip_ai_scoring
+        # Offline mode: pass Trivy --offline-scan --skip-db-update so no network
+        # is used (uses the already-downloaded Trivy vuln DB). Threaded into the
+        # image scan calls and SBOM generation below.
+        self.offline = offline
         self.analysis_score = None  # Initialize to avoid AttributeError when accessed before calculation
         
         # Initialize score chain: skip if scan_only or skip_ai_scoring flags are set
@@ -515,6 +519,7 @@ class DockerSecurityScanner:
                     "Target": target,
                     "PkgName": vulnerability.get("PkgName"),
                     "InstalledVersion": vulnerability.get("InstalledVersion"),
+                    "FixedVersion": vulnerability.get("FixedVersion"),
                     "Severity": vulnerability.get("Severity"),
                     "Title": vulnerability.get("Title"),
                     "Description": description,
@@ -551,23 +556,31 @@ class DockerSecurityScanner:
                 TextColumn("[progress.description]{task.description}"),
                 BarColumn(),
                 TimeElapsedColumn(),
-                console=None
+                # Route the spinner through the shared output console so it
+                # honors --json (which redirects human output to stderr) and
+                # never pollutes the machine-readable stdout payload.
+                console=ui.get_console(),
+                disable=ui.is_quiet(),
             ) as progress:
                 scan_task = progress.add_task(
                     f"[cyan]Scanning {self.image_name}...",
                     total=None
                 )
                 
+                trivy_cmd = [
+                    'trivy',
+                    'image',
+                    '-f', 'json',
+                    '--severity', severity,
+                    '--no-progress',
+                    '--skip-version-check',
+                ]
+                if getattr(self, 'offline', False):
+                    trivy_cmd += ['--offline-scan', '--skip-db-update']
+                trivy_cmd.append(self.image_name)
+
                 result = subprocess.run(
-                    [
-                        'trivy',
-                        'image',
-                        '-f', 'json',
-                        '--severity', severity,
-                        '--no-progress',
-                        '--skip-version-check',
-                        self.image_name
-                    ],
+                    trivy_cmd,
                     capture_output=True,
                     text=True,
                     encoding='utf-8',
@@ -625,16 +638,20 @@ class DockerSecurityScanner:
         logger.info(f"Starting Trivy scan for image: {self.image_name} with severity: {severity}")
         
         try:
+            trivy_cmd = [
+                'trivy',
+                'image',
+                '--severity', severity,
+                '--no-progress',
+                '--skip-version-check',
+                '--quiet',
+            ]
+            if getattr(self, 'offline', False):
+                trivy_cmd += ['--offline-scan', '--skip-db-update']
+            trivy_cmd.append(self.image_name)
+
             result = subprocess.run(
-                [
-                    'trivy',
-                    'image',
-                    '--severity', severity,
-                    '--no-progress',
-                    '--skip-version-check',
-                    '--quiet',
-                    self.image_name
-                ],
+                trivy_cmd,
                 capture_output=True,
                 text=True,
                 encoding='utf-8',
@@ -702,8 +719,61 @@ class DockerSecurityScanner:
         except FileNotFoundError:
             # Silently fail if tool not found, as it's optional
             result_dict['error'] = "Docker Scout not found"
-        
+
         return result_dict
+
+    def generate_sbom(self) -> Optional[str]:
+        """
+        Generate a CycloneDX SBOM for the image using Trivy's native exporter.
+
+        Trivy produces a spec-compliant CycloneDX 1.x document that lists every
+        package component in the image plus any known vulnerabilities, which is
+        exactly what supply-chain consumers (Dependency-Track, GitHub, etc.)
+        expect. Writing it here (rather than re-deriving a BOM from the filtered
+        findings) keeps DockSec's SBOM faithful to the full package inventory,
+        not just the severity-filtered vulnerability subset.
+
+        Returns:
+            The raw CycloneDX JSON string, or None if generation failed. The
+            caller (ReportGenerator) owns writing it to a file.
+        """
+        if not self.image_name:
+            return None
+
+        cmd = ['trivy', 'image', '--format', 'cyclonedx', '--no-progress',
+               '--skip-version-check', '--quiet']
+        if getattr(self, 'offline', False):
+            cmd += ['--offline-scan', '--skip-db-update']
+        cmd.append(self.image_name)
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                encoding='utf-8',
+                timeout=600,
+                shell=False
+            )
+            if result.returncode != 0 or not result.stdout:
+                logger.warning(
+                    f"Trivy SBOM generation failed for {self.image_name}: "
+                    f"{(result.stderr or '')[:200]}"
+                )
+                ui.warn("SBOM generation failed; see logs for details.")
+                return None
+            return result.stdout
+        except subprocess.TimeoutExpired:
+            ui.error("SBOM generation timed out after 600 seconds")
+            return None
+        except FileNotFoundError:
+            ui.error("Trivy not found in PATH; cannot generate SBOM.")
+            return None
+        except Exception as e:
+            logger.error(f"SBOM generation failed: {e}", exc_info=True)
+            ui.error(f"SBOM generation failed: {e}")
+            return None
+
     def run_full_scan(self, severity: str = "CRITICAL,HIGH") -> Dict:
         """
         Run all security scans and return results.

--- a/docksec/install_skill.py
+++ b/docksec/install_skill.py
@@ -1,0 +1,132 @@
+"""
+install-skill subcommand.
+
+Writes DockSec usage instructions into the well-known AI-assistant context
+files for a project (Claude Code, Cursor, Codex/AGENTS.md, Gemini, GitHub
+Copilot), so that an assistant working in that repo knows how to invoke DockSec
+to scan Dockerfiles, images, and compose files. The files are plain text the
+user can review and commit; nothing is executed.
+"""
+
+import os
+
+from docksec import output
+
+# The canonical DockSec instruction block shared across every assistant target.
+# Kept intentionally short and command-first so an assistant can act on it.
+SKILL_CONTENT = """\
+DockSec is an AI-powered Docker security scanner (OWASP Lab Project). Use it to
+scan Dockerfiles, built images, and Docker Compose stacks for vulnerabilities
+and misconfigurations, with plain-English explanations and concrete fixes.
+
+Common commands:
+
+- Scan a Dockerfile with AI analysis:
+    docksec Dockerfile
+- Scan a Dockerfile and a built image together:
+    docksec Dockerfile -i myapp:latest
+- Scan only an image (no Dockerfile):
+    docksec --image-only -i myapp:latest
+- Scan a Docker Compose file and all its services:
+    docksec --compose docker-compose.yml
+- Fast local scan with no API key (no AI):
+    docksec Dockerfile --scan-only
+- Fail CI when a HIGH-or-worse finding is present:
+    docksec -i myapp:latest --image-only --fail-on high
+- Machine-readable output for scripts:
+    docksec -i myapp:latest --image-only --json
+- SARIF for GitHub Code Scanning:
+    docksec Dockerfile --sarif
+- CycloneDX SBOM of an image for supply-chain tooling:
+    docksec --image-only -i myapp:latest --sbom
+- Fully offline (local Trivy DB, no network, no AI):
+    docksec --image-only -i myapp:latest --offline
+
+Exit codes: 0 clean, 1 findings at/above --fail-on, 2 usage error,
+3 tool/runtime error. Reports are written to ~/.docksec/results/ by default
+(override with --output-dir). See https://owasp.org/DockSec/ for full docs.
+"""
+
+# Heading used when appending into a shared instructions file, so re-running
+# install-skill updates the DockSec section in place instead of duplicating it.
+_SECTION_MARKER = "## DockSec"
+
+
+def _write_claude_code_skill(project_root: str) -> str:
+    """Write a Claude Code slash-command file (/docksec)."""
+    rel = os.path.join(".claude", "commands", "docksec.md")
+    path = os.path.join(project_root, rel)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    content = f"<!-- Run this skill with /docksec in any Claude Code session -->\n\n{SKILL_CONTENT}\n"
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+    return rel
+
+
+def _write_cursor_skill(project_root: str) -> str:
+    """Write a Cursor rules file."""
+    rel = os.path.join(".cursor", "rules", "docksec.mdc")
+    path = os.path.join(project_root, rel)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    front_matter = (
+        "---\ndescription: DockSec Docker security scanning\nglobs: []\nalwaysApply: false\n---\n\n"
+    )
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(front_matter + SKILL_CONTENT + "\n")
+    return rel
+
+
+def _write_append_skill(project_root: str, rel_path: str) -> str:
+    """Write or update a '## DockSec' section in a shared instructions file.
+
+    If the file does not exist it is created with just the DockSec section. If
+    it exists and already has a DockSec section, that section is replaced in
+    place (up to the next top-level heading); otherwise the section is appended.
+    """
+    section = f"{_SECTION_MARKER}\n\n{SKILL_CONTENT}\n"
+    path = os.path.join(project_root, rel_path)
+
+    if not os.path.exists(path):
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(section)
+        return rel_path
+
+    with open(path, "r", encoding="utf-8") as f:
+        existing = f.read()
+
+    idx = existing.find(_SECTION_MARKER)
+    if idx == -1:
+        sep = "\n" if existing.endswith("\n") else "\n\n"
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(existing + sep + section)
+        return rel_path
+
+    # Replace from the marker to the next top-level heading (or end of file).
+    after = existing.find("\n## ", idx + len(_SECTION_MARKER))
+    before = existing[:idx]
+    tail = "" if after == -1 else existing[after:]
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(before + section + tail)
+    return rel_path
+
+
+def install_skill(project_root: str = None) -> None:
+    """Install DockSec instruction files for common AI assistants."""
+    project_root = project_root or os.getcwd()
+
+    written = [
+        ("Claude Code", _write_claude_code_skill(project_root)),
+        ("Codex CLI", _write_append_skill(project_root, "AGENTS.md")),
+        ("Gemini CLI", _write_append_skill(project_root, "GEMINI.md")),
+        ("Cursor", _write_cursor_skill(project_root)),
+        ("GitHub Copilot", _write_append_skill(
+            project_root, os.path.join(".github", "copilot-instructions.md"))),
+    ]
+
+    output.section("DockSec assistant skills installed")
+    for label, rel in written:
+        output.success(f"{label:<16} {rel}")
+    output.info("Commit these files to your repo to share them with your team.")

--- a/docksec/output.py
+++ b/docksec/output.py
@@ -207,6 +207,18 @@ def quick_take(items: Iterable[str]) -> None:
         _line(Text.assemble(("  - ", "cyan"), (item, "default")))
 
 
+def fix_commands(commands: Iterable[str]) -> None:
+    """Render a 'Suggested fixes' block of copy-pasteable upgrade hints."""
+    commands = [c for c in commands if c]
+    if is_quiet() or not commands:
+        return
+    console = get_console()
+    console.print()
+    _line(Text("Suggested fixes", style="bold cyan"))
+    for cmd in commands:
+        _line(Text.assemble(("  ", "default"), (cmd, "green")))
+
+
 def report_results(paths: Dict[str, str], results_dir: str) -> None:
     """List the report formats that were written and where."""
     if is_quiet():

--- a/docksec/report_generator.py
+++ b/docksec/report_generator.py
@@ -190,6 +190,69 @@ class ReportGenerator:
             output.error(f"Failed to save SARIF report: {e}")
             return ""
 
+    def generate_cyclonedx_report(self, sbom_json: str, tool_version: str = "unknown") -> str:
+        """
+        Write a CycloneDX SBOM to disk.
+
+        The SBOM document itself is produced by Trivy (see
+        DockerSecurityScanner.generate_sbom), which emits a spec-compliant
+        CycloneDX BOM covering the full package inventory of the image. This
+        method validates it is JSON, stamps DockSec into the tool metadata so
+        downstream consumers can see which scanner emitted it, and writes it to
+        a ``.cdx.json`` file next to the other reports.
+
+        Args:
+            sbom_json: Raw CycloneDX JSON string from Trivy.
+            tool_version: DockSec version string to record in BOM metadata.
+
+        Returns:
+            Path to the generated SBOM file, or empty string on failure.
+        """
+        output_file = self._get_safe_filename("cdx.json")
+        logger.info(f"Generating CycloneDX SBOM: {output_file}")
+
+        try:
+            bom = json.loads(sbom_json)
+        except (json.JSONDecodeError, TypeError) as e:
+            logger.error(f"SBOM is not valid JSON: {e}")
+            output.error(f"Failed to parse SBOM: {e}")
+            return ""
+
+        # Record DockSec in the tool metadata without disturbing Trivy's own
+        # entry, so the BOM credits both the emitter and the wrapper.
+        try:
+            metadata = bom.setdefault("metadata", {})
+            tools = metadata.get("tools")
+            docksec_tool = {"vendor": "OWASP", "name": "DockSec", "version": tool_version}
+            if isinstance(tools, dict):
+                # CycloneDX 1.5+ shape: {"components": [...]}
+                components = tools.setdefault("components", [])
+                if isinstance(components, list):
+                    components.append({
+                        "type": "application",
+                        "author": "OWASP",
+                        "name": "DockSec",
+                        "version": tool_version,
+                    })
+            elif isinstance(tools, list):
+                # CycloneDX 1.4 shape: [{"vendor","name","version"}]
+                tools.append(docksec_tool)
+            else:
+                metadata["tools"] = [docksec_tool]
+        except Exception as e:  # metadata stamping is best-effort, never fatal
+            logger.debug(f"Could not stamp DockSec into SBOM metadata: {e}")
+
+        try:
+            with open(output_file, "w", encoding="utf-8") as f:
+                json.dump(bom, f, indent=2)
+            component_count = len(bom.get("components", []) or [])
+            logger.info(f"CycloneDX SBOM saved with {component_count} components")
+            return output_file
+        except Exception as e:
+            logger.error(f"Error saving SBOM: {e}", exc_info=True)
+            output.error(f"Failed to save SBOM: {e}")
+            return ""
+
     def _sarif_artifact_uri(self, results: Dict) -> str:
         """Resolve the file SARIF results should point at.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CycloneDX SBOM export (`--sbom`)**: writes a spec-compliant CycloneDX software bill of materials (`<image>.cdx.json`) of the scanned image, covering the full package inventory plus known vulnerabilities. The BOM is produced by Trivy's native exporter and DockSec is stamped into the tool metadata. Opt-in and independent of `--format`; requires a single image (`-i`), so it is skipped for compose runs. The path is surfaced in the report summary and in `--json` output under `report_files`.
+- **Offline mode (`--offline`)**: runs a scan with no network access, using the already-downloaded Trivy vulnerability database (`--offline-scan --skip-db-update`) and skipping the AI analysis and the Docker Scout advanced scan (both require network). Makes air-gapped scanning a single flag.
+- **`install-skill` subcommand**: `docksec install-skill` writes DockSec usage instructions into the well-known context files for AI coding assistants (Claude Code `.claude/commands/docksec.md`, Cursor `.cursor/rules/docksec.mdc`, Codex `AGENTS.md`, Gemini `GEMINI.md`, GitHub Copilot `.github/copilot-instructions.md`). Re-running updates the DockSec section in place rather than duplicating it. Added via backward-compatible subcommand dispatch: all existing flag-based usage is unchanged.
+- **Fixable-count and suggested-fix output**: the terminal result summary now reports how many findings have a fixed version available upstream (e.g. "28 of 40 have a fixed version available upstream") and prints a "Suggested fixes" block of concrete, severity-ranked, deduplicated upgrade hints (`upgrade PKG installed -> fixed`). Trivy's `FixedVersion` is now threaded into every finding, so it is also present in the JSON/CSV/SARIF outputs.
+
+### Changed
+
+- HTML report redesigned with a clean, professional, dark-mode-aware theme (replacing the previous purple-gradient style); all report data classes preserved.
+
+### Fixed
+
+- **`get_llm()` crashed with `NameError` on any LLM init failure**: the exception handler referenced a module-level `console` defined later in the file, so a bad API key / no credits / network error raised `NameError: name 'console' is not defined` instead of showing the troubleshooting steps. Now routed through the shared output layer.
+
 ## [2026.7.3] - 2026-07-02
 
 ### Fixed

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -759,6 +759,9 @@ class TestSbomAndOffline(unittest.TestCase):
                 try:
                     main()
                 except SystemExit:
+                    # main() exits via sys.exit(); the scan pass has already run
+                    # and constructed the scanner by this point, which is all
+                    # this test inspects.
                     pass
             _, kwargs = scanner_cls.call_args
             self.assertTrue(kwargs.get('offline'))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -648,5 +648,134 @@ class TestBaselineGate(unittest.TestCase):
         self.assertEqual(code, 1)
 
 
+class TestFixCommandHelpers(unittest.TestCase):
+    """Tests for the fixable-count and suggested-fix-command output helpers."""
+
+    def test_suggest_fix_commands_dedupes_and_orders_by_severity(self):
+        from docksec.cli import _suggest_fix_commands
+        results = {"json_data": [
+            {"PkgName": "zlib", "Severity": "MEDIUM", "InstalledVersion": "1.0", "FixedVersion": "1.1"},
+            {"PkgName": "openssl", "Severity": "CRITICAL", "InstalledVersion": "1.1.1", "FixedVersion": "3.0"},
+            {"PkgName": "openssl", "Severity": "HIGH", "InstalledVersion": "1.1.1", "FixedVersion": "3.0"},
+            {"PkgName": "nofix", "Severity": "HIGH", "InstalledVersion": "1.0", "FixedVersion": None},
+        ]}
+        cmds = _suggest_fix_commands(results)
+        # openssl (critical) first, deduped once; zlib present; nofix excluded.
+        self.assertEqual(cmds[0], "upgrade openssl 1.1.1 -> 3.0")
+        self.assertEqual(sum(1 for c in cmds if c.startswith("upgrade openssl")), 1)
+        self.assertTrue(any(c.startswith("upgrade zlib") for c in cmds))
+        self.assertFalse(any("nofix" in c for c in cmds))
+
+    def test_suggest_fix_commands_empty_when_no_fixed_versions(self):
+        from docksec.cli import _suggest_fix_commands
+        results = {"json_data": [
+            {"PkgName": "x", "Severity": "HIGH", "InstalledVersion": "1", "FixedVersion": None},
+        ]}
+        self.assertEqual(_suggest_fix_commands(results), [])
+
+    def test_suggest_fix_commands_respects_limit(self):
+        from docksec.cli import _suggest_fix_commands
+        results = {"json_data": [
+            {"PkgName": f"pkg{i}", "Severity": "HIGH", "InstalledVersion": "1", "FixedVersion": "2"}
+            for i in range(10)
+        ]}
+        self.assertEqual(len(_suggest_fix_commands(results, limit=3)), 3)
+
+    def test_quick_take_reports_fixable_count(self):
+        from docksec.cli import _quick_take_lines
+        from docksec import output
+        results = {"json_data": [
+            {"PkgName": "a", "Severity": "CRITICAL", "FixedVersion": "2"},
+            {"PkgName": "b", "Severity": "HIGH", "FixedVersion": None},
+        ]}
+        counts = output.count_by_severity(results["json_data"])
+        lines = _quick_take_lines(results, counts, run_ai=True)
+        self.assertTrue(any("1 of 2 have a fixed version" in ln for ln in lines))
+
+
+class TestSbomAndOffline(unittest.TestCase):
+    """Test cases for --sbom and --offline CLI wiring."""
+
+    def _run_image_only(self, extra_argv=None):
+        from docksec.cli import main
+
+        argv = ['docksec', '--image-only', '-i', 'test:latest'] + (extra_argv or [])
+        with patch('sys.argv', argv), \
+             patch('docksec.docker_scanner.DockerSecurityScanner') as scanner_cls, \
+             patch('docksec.report_generator.ReportGenerator') as report_cls:
+            scanner = Mock()
+            scanner_cls.return_value = scanner
+            scanner.image_name = "test:latest"
+            scanner.analysis_score = 90.0
+            scanner.RESULTS_DIR = '/tmp'
+            scanner.run_image_only_scan.return_value = {
+                'json_data': [],
+                'dockerfile_scan': {'skipped': True},
+                'image_scan': {'skipped': False},
+                'scan_mode': 'image_only',
+            }
+            scanner.get_security_score.return_value = 90.0
+            scanner.generate_all_reports.return_value = {'json': '/tmp/x.json'}
+            scanner.generate_sbom.return_value = '{"bomFormat":"CycloneDX"}'
+
+            report_gen = Mock()
+            report_cls.return_value = report_gen
+            report_gen.generate_cyclonedx_report.return_value = '/tmp/x.cdx.json'
+
+            code = 0
+            with patch('builtins.print'):
+                try:
+                    main()
+                except SystemExit as e:
+                    code = e.code
+            return code, scanner, report_gen
+
+    def test_sbom_not_generated_without_flag(self):
+        _, scanner, report_gen = self._run_image_only()
+        report_gen.generate_cyclonedx_report.assert_not_called()
+
+    def test_sbom_flag_generates_report(self):
+        code, scanner, report_gen = self._run_image_only(extra_argv=['--sbom'])
+        self.assertEqual(code, 0)
+        scanner.generate_sbom.assert_called_once()
+        report_gen.generate_cyclonedx_report.assert_called_once()
+
+    def test_offline_flag_passed_to_scanner(self):
+        from docksec.cli import main
+        # The scanner class must be constructed with offline=True.
+        with patch('sys.argv', ['docksec', '--image-only', '-i', 'test:latest', '--offline']), \
+             patch('docksec.docker_scanner.DockerSecurityScanner') as scanner_cls:
+            scanner = Mock()
+            scanner_cls.return_value = scanner
+            scanner.image_name = "test:latest"
+            scanner.RESULTS_DIR = '/tmp'
+            scanner.run_image_only_scan.return_value = {
+                'json_data': [], 'dockerfile_scan': {'skipped': True},
+                'image_scan': {'skipped': False}, 'scan_mode': 'image_only',
+            }
+            scanner.get_security_score.return_value = 90.0
+            scanner.generate_all_reports.return_value = {}
+            with patch('builtins.print'):
+                try:
+                    main()
+                except SystemExit:
+                    pass
+            _, kwargs = scanner_cls.call_args
+            self.assertTrue(kwargs.get('offline'))
+
+
+class TestInstallSkillDispatch(unittest.TestCase):
+    """Test the install-skill subcommand dispatch in main()."""
+
+    def test_install_skill_dispatches_and_returns(self):
+        from docksec.cli import main
+
+        with patch('sys.argv', ['docksec', 'install-skill']), \
+             patch('docksec.install_skill.install_skill') as mock_install:
+            # Must not raise SystemExit and must call install_skill().
+            main()
+            mock_install.assert_called_once()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_install_skill.py
+++ b/tests/test_install_skill.py
@@ -1,0 +1,81 @@
+"""Unit tests for the install-skill subcommand."""
+
+import os
+
+from docksec.install_skill import install_skill, SKILL_CONTENT, _SECTION_MARKER
+
+
+def _read(root, rel):
+    with open(os.path.join(root, rel), "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def test_install_skill_writes_all_targets(tmp_path):
+    install_skill(str(tmp_path))
+
+    expected = [
+        os.path.join(".claude", "commands", "docksec.md"),
+        os.path.join(".cursor", "rules", "docksec.mdc"),
+        os.path.join(".github", "copilot-instructions.md"),
+        "AGENTS.md",
+        "GEMINI.md",
+    ]
+    for rel in expected:
+        assert os.path.exists(os.path.join(tmp_path, rel)), f"missing {rel}"
+
+
+def test_claude_skill_contains_docksec_commands(tmp_path):
+    install_skill(str(tmp_path))
+    content = _read(tmp_path, os.path.join(".claude", "commands", "docksec.md"))
+    assert "docksec Dockerfile" in content
+    assert "/docksec" in content
+
+
+def test_cursor_skill_has_frontmatter(tmp_path):
+    install_skill(str(tmp_path))
+    content = _read(tmp_path, os.path.join(".cursor", "rules", "docksec.mdc"))
+    assert content.startswith("---")
+    assert "DockSec" in content
+
+
+def test_install_skill_is_idempotent(tmp_path):
+    install_skill(str(tmp_path))
+    install_skill(str(tmp_path))
+    agents = _read(tmp_path, "AGENTS.md")
+    # Section marker must appear exactly once after a second run.
+    assert agents.count(_SECTION_MARKER) == 1
+
+
+def test_install_skill_appends_to_existing_file(tmp_path):
+    # A pre-existing AGENTS.md with unrelated content should be preserved and
+    # the DockSec section appended, not overwritten.
+    existing = "# Project agents\n\nSome existing instructions.\n"
+    agents_path = tmp_path / "AGENTS.md"
+    agents_path.write_text(existing, encoding="utf-8")
+
+    install_skill(str(tmp_path))
+    content = agents_path.read_text(encoding="utf-8")
+    assert "Some existing instructions." in content
+    assert _SECTION_MARKER in content
+
+
+def test_install_skill_replaces_stale_section_in_place(tmp_path):
+    # An existing DockSec section followed by later content: re-running must
+    # replace the section but keep the trailing content.
+    agents_path = tmp_path / "AGENTS.md"
+    agents_path.write_text(
+        f"{_SECTION_MARKER}\n\nOLD CONTENT\n\n## Other tool\n\nkeep me\n",
+        encoding="utf-8",
+    )
+    install_skill(str(tmp_path))
+    content = agents_path.read_text(encoding="utf-8")
+    assert "OLD CONTENT" not in content
+    assert "## Other tool" in content
+    assert "keep me" in content
+    assert content.count(_SECTION_MARKER) == 1
+
+
+def test_skill_content_mentions_new_features():
+    # The skill block should teach the assistant the newer flags.
+    for token in ("--sbom", "--offline", "--sarif", "--fail-on"):
+        assert token in SKILL_CONTENT

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -429,3 +429,43 @@ def test_sarif_rule_omits_help_uri_when_no_primary_url():
     vuln = {"VulnerabilityID": "compose-x", "Severity": "LOW", "Title": "Issue"}
     rule = ReportGenerator._sarif_rule("compose-x", vuln)
     assert "helpUri" not in rule
+
+
+# ---------- CYCLONEDX SBOM TESTS ----------
+
+
+def test_cyclonedx_report_writes_file_and_stamps_docksec(tmp_path):
+    rg = ReportGenerator(image_name="myapp:latest", results_dir=str(tmp_path))
+    trivy_bom = json.dumps({
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.5",
+        "metadata": {"tools": {"components": []}},
+        "components": [{"type": "library", "name": "openssl", "version": "1.1.1"}],
+    })
+    path = rg.generate_cyclonedx_report(trivy_bom, tool_version="9.9.9")
+    assert os.path.exists(path)
+    assert path.endswith(".cdx.json")
+    written = json.loads(open(path).read())
+    assert written["bomFormat"] == "CycloneDX"
+    # DockSec stamped into the 1.5-style tools.components list.
+    names = [c.get("name") for c in written["metadata"]["tools"]["components"]]
+    assert "DockSec" in names
+
+
+def test_cyclonedx_report_handles_1_4_tools_list(tmp_path):
+    rg = ReportGenerator(image_name="myapp:latest", results_dir=str(tmp_path))
+    trivy_bom = json.dumps({
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.4",
+        "metadata": {"tools": [{"vendor": "aquasecurity", "name": "trivy", "version": "0.68"}]},
+        "components": [],
+    })
+    path = rg.generate_cyclonedx_report(trivy_bom, tool_version="1.0")
+    written = json.loads(open(path).read())
+    vendors = [t.get("name") for t in written["metadata"]["tools"]]
+    assert "trivy" in vendors and "DockSec" in vendors
+
+
+def test_cyclonedx_report_rejects_invalid_json(tmp_path):
+    rg = ReportGenerator(image_name="myapp:latest", results_dir=str(tmp_path))
+    assert rg.generate_cyclonedx_report("not json {", tool_version="1.0") == ""

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -445,7 +445,8 @@ def test_cyclonedx_report_writes_file_and_stamps_docksec(tmp_path):
     path = rg.generate_cyclonedx_report(trivy_bom, tool_version="9.9.9")
     assert os.path.exists(path)
     assert path.endswith(".cdx.json")
-    written = json.loads(open(path).read())
+    with open(path, encoding="utf-8") as f:
+        written = json.load(f)
     assert written["bomFormat"] == "CycloneDX"
     # DockSec stamped into the 1.5-style tools.components list.
     names = [c.get("name") for c in written["metadata"]["tools"]["components"]]
@@ -461,7 +462,8 @@ def test_cyclonedx_report_handles_1_4_tools_list(tmp_path):
         "components": [],
     })
     path = rg.generate_cyclonedx_report(trivy_bom, tool_version="1.0")
-    written = json.loads(open(path).read())
+    with open(path, encoding="utf-8") as f:
+        written = json.load(f)
     vendors = [t.get("name") for t in written["metadata"]["tools"]]
     assert "trivy" in vendors and "DockSec" in vendors
 


### PR DESCRIPTION
## Summary

Adds four features adapted from the sibling OWASP project cve-lite-cli, closing
the remaining comparison-table gaps and the CLAUDE.md "still open" parity items,
plus a fix for a `--json` output-purity bug found along the way.

## Features

- **CycloneDX SBOM export (`--sbom`)** — writes a spec-compliant CycloneDX BOM
  (`<image>.cdx.json`) of the scanned image via Trivy's native exporter, with
  DockSec stamped into the tool metadata. Opt-in and independent of `--format`;
  needs a single image (`-i`), so it is skipped for compose runs. Surfaced in the
  report summary and in `--json` under `report_files`.
- **Offline mode (`--offline`)** — scans with no network: Trivy runs with
  `--offline-scan --skip-db-update` (uses the local vuln DB) and the AI pass and
  Docker Scout are skipped. Makes air-gapped scanning a single flag.
- **`install-skill` subcommand** — `docksec install-skill` writes DockSec usage
  instructions into AI-assistant context files (Claude Code, Cursor, Codex
  `AGENTS.md`, Gemini `GEMINI.md`, GitHub Copilot). Idempotent (updates the
  DockSec section in place). Added via backward-compatible subcommand dispatch:
  all existing flag-based usage is unchanged.
- **Fixable-count and suggested-fix output** — the result summary now reports how
  many findings have an upstream fixed version and prints a "Suggested fixes"
  block of severity-ranked, deduplicated `upgrade PKG old -> new` hints. Trivy's
  `FixedVersion` is threaded into every finding (also present in JSON/CSV/SARIF).

## Fixed

- `--json` stdout was polluted by the Rich progress spinner, breaking the
  machine-readable contract for CI consumers. The spinner now routes through the
  shared output console (stderr in `--json` mode), so stdout is pure JSON.

## Docs

- README: SBOM comparison row flipped to supported, new `install-skill` row,
  usage examples, and dedicated sections for SBOM / offline / install-skill.
- CHANGELOG: `[Unreleased]` Added/Changed/Fixed entries.
- CLAUDE.md: the three cve-lite parity items moved to resolved; new flags,
  subcommand, and `install_skill.py` module documented.

## Testing

- `pytest`: 175 passed (was 157; +18 new tests covering the CycloneDX writer,
  install-skill idempotency/append/in-place-replace, the fix-command helper, and
  `--sbom` / `--offline` / `install-skill` CLI wiring).
- End-to-end verified against `python:3.9-slim` and `alpine:3.18`: SBOM validity
  (CycloneDX 1.6), `--json` purity, offline scanning, and the fix-command output.

## Notes / not included

- CycloneDX only (no SPDX yet); `--offline` relies on the local Trivy DB rather
  than a bundled advisory DB. Both noted as future work in CLAUDE.md.
- `setup.py` version is unchanged (`2026.7.2`); a release bump for these features
  is deliberately left out of this PR.
