### PR TITLE
fix(cli): add verbose log flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,17 @@ docksec -i myapp:latest --image-only --baseline .docksec-baseline.json --fail-on
 # Reduce output to warnings, errors, and the result summary
 docksec Dockerfile --scan-only --quiet
 
+# Show INFO-level diagnostic logs on stderr for troubleshooting
+docksec Dockerfile --scan-only --verbose
+
 # Disable colored output (also honors the NO_COLOR env var)
 docksec Dockerfile --no-color
 ```
 
 Every scan ends with a result summary: a severity table, the security score with a
 rating, a "Quick take" action block, the generated reports, and a suggested next
-command. Use `--quiet` for a compact result and `--no-color` for plain output.
+command. Use `--quiet` for a compact result, `--verbose` for INFO-level
+diagnostic logs, and `--no-color` for plain output.
 
 ### Machine-readable output
 

--- a/docksec/cli.py
+++ b/docksec/cli.py
@@ -74,6 +74,7 @@ def main() -> None:
     parser.add_argument('--baseline', dest='baseline', metavar='FILE', help='Path to a baseline file; with --fail-on, only findings not present in the baseline trigger the gate')
     parser.add_argument('--update-baseline', dest='update_baseline', action='store_true', help='Write the current scan findings to --baseline instead of gating against it')
     parser.add_argument('--quiet', action='store_true', help='Reduce output to warnings, errors, and the result summary')
+    parser.add_argument('-v', '--verbose', action='store_true', help='Show INFO-level log lines on stderr')
     parser.add_argument('--no-color', action='store_true', help='Disable colored output (also honors the NO_COLOR env var)')
     parser.add_argument('--version', action='version', version=f'DockSec {get_version()}')
 
@@ -97,6 +98,9 @@ def main() -> None:
     # Set compact output mode if requested
     if args.compact_output:
         os.environ["DOCKSEC_COMPACT_OUTPUT"] = "true"
+
+    if args.verbose and not os.getenv("DOCKSEC_LOG_LEVEL"):
+        os.environ["DOCKSEC_LOG_LEVEL"] = "INFO"
 
     # Resolve the severity filter: CLI flag > DOCKSEC_DEFAULT_SEVERITY env > default.
     from docksec.config_manager import get_config

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -249,6 +249,50 @@ class TestCLI(unittest.TestCase):
                 main()
         self.assertNotEqual(ctx.exception.code, 2)
 
+    @patch("sys.argv", ["docksec", "--image-only", "-i", "test:latest", "--verbose"])
+    @patch("docksec.docker_scanner.DockerSecurityScanner")
+    def test_verbose_flag_sets_info_log_level(self, mock_scanner_class):
+        """--verbose is a shortcut for DOCKSEC_LOG_LEVEL=INFO."""
+        from docksec.cli import main
+
+        scanner = Mock()
+        mock_scanner_class.return_value = scanner
+        scanner.run_image_only_scan.return_value = {
+            "json_data": [],
+            "dockerfile_scan": {"skipped": True},
+            "image_scan": {"skipped": False},
+            "scan_mode": "image_only",
+        }
+        scanner.get_security_score.return_value = 90.0
+        scanner.generate_all_reports.return_value = {}
+        scanner.RESULTS_DIR = "/tmp"
+
+        with patch.dict(os.environ, {}, clear=True):
+            main()
+            self.assertEqual(os.environ["DOCKSEC_LOG_LEVEL"], "INFO")
+
+    @patch("sys.argv", ["docksec", "--image-only", "-i", "test:latest", "-v"])
+    @patch("docksec.docker_scanner.DockerSecurityScanner")
+    def test_verbose_flag_preserves_explicit_log_level(self, mock_scanner_class):
+        """An existing DOCKSEC_LOG_LEVEL takes priority over -v."""
+        from docksec.cli import main
+
+        scanner = Mock()
+        mock_scanner_class.return_value = scanner
+        scanner.run_image_only_scan.return_value = {
+            "json_data": [],
+            "dockerfile_scan": {"skipped": True},
+            "image_scan": {"skipped": False},
+            "scan_mode": "image_only",
+        }
+        scanner.get_security_score.return_value = 90.0
+        scanner.generate_all_reports.return_value = {}
+        scanner.RESULTS_DIR = "/tmp"
+
+        with patch.dict(os.environ, {"DOCKSEC_LOG_LEVEL": "DEBUG"}, clear=True):
+            main()
+            self.assertEqual(os.environ["DOCKSEC_LOG_LEVEL"], "DEBUG")
+
 
 class TestCLIHelpers(unittest.TestCase):
     """Test cases for the CLI summary helper functions."""


### PR DESCRIPTION
## Description

Adds `-v` / `--verbose` as a shortcut for INFO-level DockSec logs without overriding an existing `DOCKSEC_LOG_LEVEL`.

Closes #129

## Type of Change

- [x] New feature
- [x] Documentation update
- [x] Test update

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

**Test Configuration:**
- Python version: 3.12.13
- Operating System: macOS
- DockSec version: 2026.7.3

## Checklist

- [x] Code follows the style guidelines of this project
- [x] Self-review completed
- [x] Hard-to-understand areas are commented
- [x] Documentation updated where needed
- [x] No new warnings or errors introduced
- [x] Tests added that prove the fix or feature works
- [x] All existing tests pass
- [x] Dependent changes have been merged and published
- [x] Spelling checked

## Screenshots (if applicable)

N/A

## Related Issues / PRs

- Relates to #129

---

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
