### PR TITLE
feat(cli): add --log-file flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ docksec Dockerfile --scan-only --quiet
 # Show INFO-level diagnostic logs on stderr for troubleshooting
 docksec Dockerfile --scan-only --verbose
 
+# Also append those logs to a file for CI to collect as an artifact
+docksec Dockerfile --scan-only --verbose --log-file logs/docksec.log
+
 # Disable colored output (also honors the NO_COLOR env var)
 docksec Dockerfile --no-color
 ```
@@ -144,7 +147,8 @@ docksec Dockerfile --no-color
 Every scan ends with a result summary: a severity table, the security score with a
 rating, a "Quick take" action block, the generated reports, and a suggested next
 command. Use `--quiet` for a compact result, `--verbose` for INFO-level
-diagnostic logs, and `--no-color` for plain output.
+diagnostic logs, `--log-file FILE` to also append those logs to a file, and
+`--no-color` for plain output.
 
 ### Machine-readable output
 

--- a/docksec/cli.py
+++ b/docksec/cli.py
@@ -75,6 +75,7 @@ def main() -> None:
     parser.add_argument('--update-baseline', dest='update_baseline', action='store_true', help='Write the current scan findings to --baseline instead of gating against it')
     parser.add_argument('--quiet', action='store_true', help='Reduce output to warnings, errors, and the result summary')
     parser.add_argument('-v', '--verbose', action='store_true', help='Show INFO-level log lines on stderr')
+    parser.add_argument('--log-file', dest='log_file', metavar='FILE', help='Also append log lines to FILE, creating missing parent directories; combine with --verbose to capture INFO-level logs')
     parser.add_argument('--no-color', action='store_true', help='Disable colored output (also honors the NO_COLOR env var)')
     parser.add_argument('--version', action='version', version=f'DockSec {get_version()}')
 
@@ -101,6 +102,20 @@ def main() -> None:
 
     if args.verbose and not os.getenv("DOCKSEC_LOG_LEVEL"):
         os.environ["DOCKSEC_LOG_LEVEL"] = "INFO"
+
+    # Resolve --log-file before any logger is built, so get_custom_logger can
+    # attach its file handler. Opening the path here surfaces an unwritable
+    # destination as a clean CLI error instead of a traceback mid-scan.
+    if args.log_file:
+        try:
+            parent = os.path.dirname(os.path.abspath(args.log_file))
+            os.makedirs(parent, exist_ok=True)
+            with open(args.log_file, 'a', encoding='utf-8'):
+                pass
+        except OSError as exc:
+            output.error(f"Cannot write to --log-file '{args.log_file}': {exc}")
+            sys.exit(2)
+        os.environ["DOCKSEC_LOG_FILE"] = args.log_file
 
     # Resolve the severity filter: CLI flag > DOCKSEC_DEFAULT_SEVERITY env > default.
     from docksec.config_manager import get_config

--- a/docksec/utils.py
+++ b/docksec/utils.py
@@ -87,6 +87,15 @@ def get_custom_logger(name: str = 'Docksec', user_facing: bool = False):
         handler = logging.StreamHandler(sys.stderr)
         handler.setFormatter(formatter)
         logger.addHandler(handler)
+    # DOCKSEC_LOG_FILE (set by --log-file) duplicates log output to a file so a
+    # CI run can collect it as an artifact. Handlers append: every module builds
+    # its own logger, so several FileHandlers share one path and truncating here
+    # would let them clobber each other.
+    log_file = os.getenv("DOCKSEC_LOG_FILE")
+    if log_file and not any(isinstance(h, logging.FileHandler) for h in logger.handlers):
+        file_handler = logging.FileHandler(log_file, encoding='utf-8')
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
     for handler in logger.handlers:
         handler.setLevel(log_level)
     # Don't propagate to the root logger; prevents duplicate emission.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -293,6 +293,68 @@ class TestCLI(unittest.TestCase):
             main()
             self.assertEqual(os.environ["DOCKSEC_LOG_LEVEL"], "DEBUG")
 
+    @staticmethod
+    def _close_file_handlers():
+        """Drop any FileHandler a run left open, so tearDown can remove the dir."""
+        import logging
+
+        loggers = [logging.getLogger()] + [
+            logging.getLogger(name) for name in logging.root.manager.loggerDict
+        ]
+        for log in loggers:
+            for handler in list(getattr(log, 'handlers', [])):
+                if isinstance(handler, logging.FileHandler):
+                    handler.close()
+                    log.removeHandler(handler)
+
+    @patch("docksec.docker_scanner.DockerSecurityScanner")
+    def test_log_file_flag_creates_file_and_parent_dirs(self, mock_scanner_class):
+        """--log-file exports DOCKSEC_LOG_FILE and creates missing parents."""
+        from docksec.cli import main
+
+        scanner = Mock()
+        mock_scanner_class.return_value = scanner
+        scanner.run_image_only_scan.return_value = {
+            "json_data": [],
+            "dockerfile_scan": {"skipped": True},
+            "image_scan": {"skipped": False},
+            "scan_mode": "image_only",
+        }
+        scanner.get_security_score.return_value = 90.0
+        scanner.generate_all_reports.return_value = {}
+        scanner.RESULTS_DIR = "/tmp"
+
+        log_path = os.path.join(self.test_dir, "nested", "dir", "docksec.log")
+        argv = ["docksec", "--image-only", "-i", "test:latest", "--log-file", log_path]
+        try:
+            with patch.object(sys, "argv", argv):
+                with patch.dict(os.environ, {}, clear=True):
+                    main()
+                    self.assertEqual(os.environ["DOCKSEC_LOG_FILE"], log_path)
+            self.assertTrue(os.path.isfile(log_path))
+        finally:
+            self._close_file_handlers()
+
+    def test_log_file_flag_errors_on_unwritable_path(self):
+        """An unwritable --log-file path exits 2 instead of raising."""
+        from docksec.cli import main
+
+        blocker = os.path.join(self.test_dir, "blocker")
+        with open(blocker, 'w') as handle:
+            handle.write("not a directory")
+        log_path = os.path.join(blocker, "docksec.log")
+
+        argv = ["docksec", "--image-only", "-i", "test:latest", "--log-file", log_path]
+        try:
+            with patch.object(sys, "argv", argv):
+                with patch.dict(os.environ, {}, clear=True):
+                    with self.assertRaises(SystemExit) as ctx:
+                        main()
+            self.assertEqual(ctx.exception.code, 2)
+            self.assertNotIn("DOCKSEC_LOG_FILE", os.environ)
+        finally:
+            self._close_file_handlers()
+
 
 class TestCLIHelpers(unittest.TestCase):
     """Test cases for the CLI summary helper functions."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -85,7 +85,71 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(len(stream_handlers), 1)
         self.assertIs(stream_handlers[0].stream, sys.stderr)
         self.assertFalse(logger.propagate)
-    
+
+    def test_get_custom_logger_duplicates_to_log_file(self):
+        """DOCKSEC_LOG_FILE (set by --log-file) mirrors log lines into the file
+        while the stderr handler keeps emitting them."""
+        import sys
+        import logging
+        from docksec.utils import get_custom_logger
+
+        old_env = {key: os.environ.get(key) for key in
+                   ("DOCKSEC_LOG_FILE", "DOCKSEC_LOG_LEVEL", "DOCKSEC_CLI_MODE")}
+        logger = None
+        try:
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                log_path = os.path.join(tmp_dir, 'docksec.log')
+                os.environ["DOCKSEC_LOG_FILE"] = log_path
+                os.environ["DOCKSEC_LOG_LEVEL"] = "INFO"
+                os.environ.pop("DOCKSEC_CLI_MODE", None)
+
+                logger = get_custom_logger('TestLoggerLogFile')
+                logger.info("this line lands in the log file")
+
+                file_handlers = [h for h in logger.handlers
+                                 if isinstance(h, logging.FileHandler)]
+                self.assertEqual(len(file_handlers), 1)
+                with open(log_path, encoding='utf-8') as handle:
+                    self.assertIn("this line lands in the log file", handle.read())
+
+                # The stderr handler survives alongside the file handler.
+                stream_handlers = [h for h in logger.handlers
+                                   if isinstance(h, logging.StreamHandler)
+                                   and not isinstance(h, logging.FileHandler)]
+                self.assertEqual(len(stream_handlers), 1)
+                self.assertIs(stream_handlers[0].stream, sys.stderr)
+
+                # Release the file handle so the temp dir can be removed.
+                for handler in list(logger.handlers):
+                    handler.close()
+                    logger.removeHandler(handler)
+                logger = None
+        finally:
+            if logger is not None:
+                for handler in list(logger.handlers):
+                    handler.close()
+                    logger.removeHandler(handler)
+            for key, val in old_env.items():
+                if val is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = val
+
+    def test_get_custom_logger_without_log_file_adds_no_file_handler(self):
+        """Without DOCKSEC_LOG_FILE the logger stays stderr-only, as before."""
+        import logging
+        from docksec.utils import get_custom_logger
+
+        old_log_file = os.environ.pop("DOCKSEC_LOG_FILE", None)
+        try:
+            logger = get_custom_logger('TestLoggerNoLogFile')
+            file_handlers = [h for h in logger.handlers
+                             if isinstance(h, logging.FileHandler)]
+            self.assertEqual(file_handlers, [])
+        finally:
+            if old_log_file is not None:
+                os.environ["DOCKSEC_LOG_FILE"] = old_log_file
+
     def test_load_docker_file(self):
         """Test Dockerfile loading."""
         from docksec.utils import load_docker_file


### PR DESCRIPTION
# Pull Request

## Description

Adds a `--log-file PATH` flag that attaches a `logging.FileHandler` alongside the existing stderr handler in `get_custom_logger`, using the same formatter, so log output is duplicated to a file. This makes it possible to collect DockSec logs as a CI artifact after a run finishes, instead of having to capture stderr.

`cli.py` exports the resolved path as `DOCKSEC_LOG_FILE` before any logger is built, mirroring how `DOCKSEC_CLI_MODE` and `DOCKSEC_LOG_LEVEL` are set. Missing parent directories are created, and an unwritable path is reported through the `docksec.output` layer with exit code 2 rather than raising mid-scan.

**Append, not overwrite.** Every module calls `get_custom_logger(__name__)`, so a single run attaches several `FileHandler`s to the same path. In `mode='w'` each one truncates the file as it opens and lines are lost. Appending is also the default for a bare `logging.FileHandler(path)`, as the issue describes.

The file mirrors stderr, so it honors the current log level. In CLI mode that level is `ERROR`, so `--log-file` on its own produces an empty file for a clean run; pair it with `--verbose` (added in #151) to capture INFO-level logs. Happy to make the file always capture INFO instead if that's the preferred behavior.

Closes #130

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update
- [ ] Build / CI configuration
- [ ] Security fix

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

Four new tests: two in `tests/test_utils.py` covering a log line landing in the file and the stderr-only default, two in `tests/test_cli.py` covering parent-directory creation and the unwritable-path exit. Full suite: **184 passed**.

Manual run, matching the new README example. The same lines appear on stderr and in the file, and `logs/` is created automatically:

```console
$ docksec --compose docker-compose.yml --verbose --log-file logs/docksec.log

--- stderr (first 4 log lines) ---
INFO - docksec.utils - Line 194: Initializing LLM with provider: openai, model: gpt-4o
ERROR - docksec.utils - Line 280: Failed to initialize LLM: OpenAI API key not found. Set OPENAI_API_KEY environment variable or use --scan-only mode.
INFO - docksec.compose_scanner - Line 385: Scanning service web (Dockerfile: None, Image: nginx:latest)
INFO - docksec.utils - Line 194: Initializing LLM with provider: openai, model: gpt-4o

--- logs/docksec.log (first 4 lines) ---
INFO - docksec.utils - Line 194: Initializing LLM with provider: openai, model: gpt-4o
ERROR - docksec.utils - Line 280: Failed to initialize LLM: OpenAI API key not found. Set OPENAI_API_KEY environment variable or use --scan-only mode.
INFO - docksec.compose_scanner - Line 385: Scanning service web (Dockerfile: None, Image: nginx:latest)
INFO - docksec.utils - Line 194: Initializing LLM with provider: openai, model: gpt-4o

total lines in file: 20
parent dir auto-created: True
```

An unwritable destination fails cleanly, before the scan starts:

```console
$ docksec --compose docker-compose.yml --log-file blocker/docksec.log
error Cannot write to --log-file 'blocker/docksec.log': [WinError 183] Cannot create a file when that file already exists: 'blocker'
$ echo $?
2
```

Without `--log-file`, stdout and stderr are unchanged. (The `Line NNN` values in existing log lines shift by 9, because the formatter embeds `%(lineno)d` and this adds lines above those statements in `utils.py`.)

**Test Configuration:**
- Python version: 3.12.10
- Operating System: Windows 11
- DockSec version: 2026.7.3

## Checklist

- [x] Code follows the style guidelines of this project
- [x] Self-review completed
- [x] Hard-to-understand areas are commented
- [x] Documentation updated where needed
- [x] No new warnings or errors introduced
- [x] Tests added that prove the fix or feature works
- [x] All existing tests pass
- [x] Dependent changes have been merged and published
- [x] Spelling checked

## Related Issues / PRs

- Closes #130
- Relates to #52 (this was split out of it)
- Builds on #151, which added `--verbose`
- Unrelated to this change, but found while setting up to work on it: #153

---

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
